### PR TITLE
Support `dgdp` in discrete costs within `adjoint_sensitivities` interface

### DIFF
--- a/docs/src/ad_examples/adjoint_continuous_functional.md
+++ b/docs/src/ad_examples/adjoint_continuous_functional.md
@@ -84,7 +84,7 @@ To get the adjoint sensitivities, we call:
 ```@example continuousadjoint
 prob = ODEProblem(f,[1.0;1.0],(0.0,10.0),p)
 sol = solve(prob,DP8())
-res = adjoint_sensitivities(sol,Vern9(),dg_continuous=dg,g=g,abstol=1e-8,reltol=1e-8)
+res = adjoint_sensitivities(sol,Vern9(),dgdu_continuous=dg,g=g,abstol=1e-8,reltol=1e-8)
 ```
 
 Notice that we can check this against autodifferentiation and numerical

--- a/docs/src/ad_examples/direct_sensitivity.md
+++ b/docs/src/ad_examples/direct_sensitivity.md
@@ -112,7 +112,7 @@ sensitivities, call:
 
 ```@example directsense
 ts = 0:0.5:10
-res = adjoint_sensitivities(sol,Vern9(),t=ts,dg_discrete=dg,abstol=1e-14,
+res = adjoint_sensitivities(sol,Vern9(),t=ts,dgdu_discrete=dg,abstol=1e-14,
                             reltol=1e-14)
 ```
 

--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -1,4 +1,5 @@
-struct AdjointDiffCache{UF, PF, G, TJ, PJT, uType, JC, GC, PJC, JNC, PJNC, rateType, DG, DI,
+struct AdjointDiffCache{UF, PF, G, TJ, PJT, uType, JC, GC, PJC, JNC, PJNC, rateType, DG1,
+                        DG2, DI,
                         AI, FM}
     uf::UF
     pf::PF
@@ -12,7 +13,8 @@ struct AdjointDiffCache{UF, PF, G, TJ, PJT, uType, JC, GC, PJC, JNC, PJNC, rateT
     jac_noise_config::JNC
     paramjac_noise_config::PJNC
     f_cache::rateType
-    dg::DG
+    dgdu::DG1
+    dgdp::DG2
     diffvar_idxs::DI
     algevar_idxs::AI
     factorized_mass_matrix::FM
@@ -24,8 +26,9 @@ end
 
 return (AdjointDiffCache, y)
 """
-function adjointdiffcache(g::G, sensealg, discrete, sol, dg::DG, f; quad = false,
-                          noiseterm = false, needs_jac = false) where {G, DG}
+function adjointdiffcache(g::G, sensealg, discrete, sol, dgdu::DG1, dgdp::DG2, f;
+                          quad = false,
+                          noiseterm = false, needs_jac = false) where {G, DG1, DG2}
     prob = sol.prob
     if prob isa DiffEqBase.SteadyStateProblem
         @unpack u0, p = prob
@@ -71,11 +74,10 @@ function adjointdiffcache(g::G, sensealg, discrete, sol, dg::DG, f; quad = false
     end
 
     if !discrete
-        @assert dg isa Tuple && length(dg) == 2
-        if dg[1] !== nothing
+        if dgdu !== nothing
             pg = nothing
             pg_config = nothing
-            if dg[2] !== nothing
+            if dgdp !== nothing
                 dg_val = (similar(u0, numindvar), similar(u0, numparams))
                 dg_val[1] .= false
                 dg_val[2] .= false
@@ -356,7 +358,7 @@ function adjointdiffcache(g::G, sensealg, discrete, sol, dg::DG, f; quad = false
     adjoint_cache = AdjointDiffCache(uf, pf, pg, J, pJ, dg_val,
                                      jac_config, pg_config, paramjac_config,
                                      jac_noise_config, paramjac_noise_config,
-                                     f_cache, dg, diffvar_idxs, algevar_idxs,
+                                     f_cache, dgdu, dgdp, diffvar_idxs, algevar_idxs,
                                      factorized_mass_matrix, issemiexplicitdae)
 
     return adjoint_cache, y
@@ -367,7 +369,8 @@ function getprob(S::SensitivityFunction)
 end
 inplace_sensitivity(S::SensitivityFunction) = isinplace(getprob(S))
 
-struct ReverseLossCallback{λType, timeType, yType, RefType, FMType, AlgType, gType,
+struct ReverseLossCallback{λType, timeType, yType, RefType, FMType, AlgType, dg1Type,
+                           dg2Type,
                            cacheType}
     isq::Bool
     λ::λType
@@ -377,11 +380,12 @@ struct ReverseLossCallback{λType, timeType, yType, RefType, FMType, AlgType, gT
     idx::Int
     F::FMType
     sensealg::AlgType
-    dg::gType
+    dgdu::dg1Type
+    dgdp::dg2Type
     diffcache::cacheType
 end
 
-function ReverseLossCallback(sensefun, λ, t, dg, cur_time)
+function ReverseLossCallback(sensefun, λ, t, dgdu, dgdp, cur_time)
     @unpack sensealg, y = sensefun
     isq = (sensealg isa QuadratureAdjoint)
 
@@ -390,14 +394,12 @@ function ReverseLossCallback(sensefun, λ, t, dg, cur_time)
     idx = length(prob.u0)
 
     return ReverseLossCallback(isq, λ, t, y, cur_time, idx, factorized_mass_matrix,
-                               sensealg, dg, sensefun.diffcache)
+                               sensealg, dgdu, dgdp, sensefun.diffcache)
 end
 
 function (f::ReverseLossCallback)(integrator)
-    @unpack isq, λ, t, y, cur_time, idx, F, sensealg, dg = f
+    @unpack isq, λ, t, y, cur_time, idx, F, sensealg, dgdu, dgdp = f
     @unpack diffvar_idxs, algevar_idxs, issemiexplicitdae, J, uf, f_cache, jac_config = f.diffcache
-
-    dgdu_discrete, dgdp_discrete = dg
 
     p, u = integrator.p, integrator.u
 
@@ -407,12 +409,12 @@ function (f::ReverseLossCallback)(integrator)
 
     # Warning: alias here! Be careful with λ
     gᵤ = isq ? λ : @view(λ[1:idx])
-    if dgdu_discrete !== nothing
-        dgdu_discrete(gᵤ, y, p, t[cur_time[]], cur_time[])
+    if dgdu !== nothing
+        dgdu(gᵤ, y, p, t[cur_time[]], cur_time[])
         # add discrete dgdp contribution
-        if dgdp_discrete !== nothing && !isq
+        if dgdp !== nothing && !isq
             gp = @view(λ[(idx + 1):end])
-            dgdp_discrete(gp, y, p, t[cur_time[]], cur_time[])
+            dgdp(gp, y, p, t[cur_time[]], cur_time[])
             u[(idx + 1):length(λ)] .+= gp
         end
     end
@@ -439,7 +441,8 @@ function (f::ReverseLossCallback)(integrator)
 end
 
 # handle discrete loss contributions
-function generate_callbacks(sensefun, dg, λ, t, t0, callback, init_cb, terminated = false)
+function generate_callbacks(sensefun, dgdu, dgdp, λ, t, t0, callback, init_cb,
+                            terminated = false)
     if sensefun isa NILSASSensitivityFunction
         @unpack sensealg = sensefun.S
     else
@@ -452,13 +455,14 @@ function generate_callbacks(sensefun, dg, λ, t, t0, callback, init_cb, terminat
         cur_time = Ref(length(t))
     end
 
-    reverse_cbs = setup_reverse_callbacks(callback, sensealg, dg, cur_time, terminated)
+    reverse_cbs = setup_reverse_callbacks(callback, sensealg, dgdu, dgdp, cur_time,
+                                          terminated)
     init_cb || return reverse_cbs, nothing
 
     # callbacks can lead to non-unique time points
     _t, duplicate_iterator_times = separate_nonunique(t)
 
-    rlcb = ReverseLossCallback(sensefun, λ, t, dg, cur_time)
+    rlcb = ReverseLossCallback(sensefun, λ, t, dgdu, dgdp, cur_time)
 
     if eltype(_t) !== typeof(t0)
         _t = convert.(typeof(t0), _t)
@@ -468,7 +472,7 @@ function generate_callbacks(sensefun, dg, λ, t, t0, callback, init_cb, terminat
     # handle duplicates (currently only for double occurances)
     if duplicate_iterator_times !== nothing
         # use same ref for cur_time to cope with concrete_solve
-        cbrev_dupl_affect = ReverseLossCallback(sensefun, λ, t, dg, cur_time)
+        cbrev_dupl_affect = ReverseLossCallback(sensefun, λ, t, dgdu, dgdp, cur_time)
         cb_dupl = PresetTimeCallback(duplicate_iterator_times[1], cbrev_dupl_affect)
         return CallbackSet(cb, reverse_cbs, cb_dupl), duplicate_iterator_times
     else

--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -303,7 +303,8 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback, DiscreteCallback
             if cb.save_positions[1] == true
                 # if the callback saved the first position, we need to implicitly correct this value as well
                 loss_indx = correction.cur_time[]
-                implicit_correction!(Lu_left, dy_left, correction, y, integrator, g,
+                implicit_correction!(Lu_left, dy_left, correction, y, integrator, dgdu,
+                                     dgdp,
                                      loss_indx)
                 dλ .+= Lu_left
             end

--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -182,7 +182,7 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback, DiscreteCallback
         cb.affect!.correction.terminated = terminated # flag if time evolution was terminated by callback
     end
 
-    dgdp === nothing &&
+    dgdp !== nothing &&
         error("We have not yet implemented custom adjoint rules to support parameter-dependent loss functions for hybrid systems.")
 
     # ReverseLossCallback adds gradients before and after the callback if save_positions is (true, true).

--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -159,24 +159,31 @@ vjps as described in https://arxiv.org/pdf/1905.10403.pdf Equation 13.
 
 For more information, see https://github.com/SciML/SciMLSensitivity.jl/issues/4
 """
-function setup_reverse_callbacks(cb, sensealg, g, cur_time, terminated)
-    setup_reverse_callbacks(CallbackSet(cb), sensealg, g, cur_time, terminated)
+function setup_reverse_callbacks(cb, sensealg, dgdu, dgdp, cur_time, terminated)
+    setup_reverse_callbacks(CallbackSet(cb), sensealg, dgdu, dgdp, cur_time, terminated)
 end
-function setup_reverse_callbacks(cb::CallbackSet, sensealg, g, cur_time, terminated)
-    cb = CallbackSet(_setup_reverse_callbacks.(cb.continuous_callbacks, (sensealg,), (g,),
+function setup_reverse_callbacks(cb::CallbackSet, sensealg, dgdu, dgdp, cur_time,
+                                 terminated)
+    cb = CallbackSet(_setup_reverse_callbacks.(cb.continuous_callbacks, (sensealg,),
+                                               (dgdu,),
+                                               (dgdp,),
                                                (cur_time,), (terminated,))...,
                      reverse(_setup_reverse_callbacks.(cb.discrete_callbacks, (sensealg,),
-                                                       (g,), (cur_time,), (terminated,)))...)
+                                                       (dgdu,),
+                                                       (dgdp,), (cur_time,), (terminated,)))...)
     return cb
 end
 
 function _setup_reverse_callbacks(cb::Union{ContinuousCallback, DiscreteCallback,
-                                            VectorContinuousCallback}, sensealg, g,
+                                            VectorContinuousCallback}, sensealg, dgdu, dgdp,
                                   loss_ref, terminated)
     if cb isa Union{ContinuousCallback, VectorContinuousCallback} && cb.affect! !== nothing
         cb.affect!.correction.cur_time = loss_ref # set cur_time
         cb.affect!.correction.terminated = terminated # flag if time evolution was terminated by callback
     end
+
+    dgdp === nothing &&
+        error("We have not yet implemented custom adjoint rules to support parameter-dependent loss functions for hybrid systems.")
 
     # ReverseLossCallback adds gradients before and after the callback if save_positions is (true, true).
     # This, however, means that we must check the save_positions setting within the callback.
@@ -233,7 +240,7 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback, DiscreteCallback
             # if callback did not terminate the time evolution, we have to compute one more correction term.
             if cb.save_positions[2] && !correction.terminated
                 loss_indx = correction.cur_time[] + 1
-                loss_correction!(Lu_right, y, integrator, g, loss_indx)
+                loss_correction!(Lu_right, y, integrator, dgdu, dgdp, loss_indx)
             else
                 Lu_right .*= false
             end
@@ -427,10 +434,10 @@ function dgdt(dy, correction, sensealg, y, integrator, tprev, event_idx)
     return nothing
 end
 
-function loss_correction!(Lu, y, integrator, g, indx)
+function loss_correction!(Lu, y, integrator, dgdu, dgdp, indx)
     # ∂L∂t correction should be added if L depends explicitly on time.
     p, t = integrator.p, integrator.t
-    g(Lu, y, p, t, indx)
+    dgdu(Lu, y, p, t, indx)
     return nothing
 end
 
@@ -452,7 +459,7 @@ function implicit_correction!(Lu, λ, dy, correction)
     return nothing
 end
 
-function implicit_correction!(Lu, dy, correction, y, integrator, g, indx)
+function implicit_correction!(Lu, dy, correction, y, integrator, dgdu, dgdp, indx)
     @unpack gu_val = correction
 
     p, t = integrator.p, integrator.t
@@ -460,7 +467,7 @@ function implicit_correction!(Lu, dy, correction, y, integrator, g, indx)
     # loss function gradient (not condition!)
     # ∂L∂t correction should be added, also ∂L∂p is missing.
     # correct adjoint
-    g(Lu, y, p, t, indx)
+    dgdu(Lu, y, p, t, indx)
 
     Lu .= dot(Lu, dy) * gu_val
 

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -313,7 +313,7 @@ function DiffEqBase._concrete_solve_adjoint(prob, alg,
             cb2 = cb
         end
 
-        du0, dp = adjoint_sensitivities(sol, alg, args...; t = ts, dg_discrete = df,
+        du0, dp = adjoint_sensitivities(sol, alg, args...; t = ts, dgdu_discrete = df,
                                         sensealg = sensealg,
                                         callback = cb2,
                                         kwargs_adj...)
@@ -997,16 +997,17 @@ function DiffEqBase._concrete_solve_adjoint(prob, alg,
         end
 
         if sensealg isa ForwardLSS
-            lss_problem = ForwardLSSProblem(sol, sensealg, t = ts, dg_discrete = df)
+            lss_problem = ForwardLSSProblem(sol, sensealg, t = ts, dgdu_discrete = df)
             dp = shadow_forward(lss_problem)
         elseif sensealg isa AdjointLSS
-            adjointlss_problem = AdjointLSSProblem(sol, sensealg, t = ts, dg_discrete = df)
+            adjointlss_problem = AdjointLSSProblem(sol, sensealg, t = ts,
+                                                   dgdu_discrete = df)
             dp = shadow_adjoint(adjointlss_problem)
         elseif sensealg isa NILSS
-            nilss_prob = NILSSProblem(_prob, sensealg, t = ts, dg_discrete = df)
+            nilss_prob = NILSSProblem(_prob, sensealg, t = ts, dgdu_discrete = df)
             dp = shadow_forward(nilss_prob, alg)
         elseif sensealg isa NILSAS
-            nilsas_prob = NILSASProblem(_prob, sensealg, t = ts, dg_discrete = df)
+            nilsas_prob = NILSASProblem(_prob, sensealg, t = ts, dgdu_discrete = df)
             dp = shadow_adjoint(nilsas_prob, alg)
         else
             error("No concrete_solve implementation found for sensealg `$sensealg`. Did you spell the sensitivity algorithm correctly? Please report this error.")

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -838,17 +838,17 @@ end
 
 function accumulate_cost!(dλ, y, p, t, S::TS,
                           dgrad = nothing) where {TS <: SensitivityFunction}
-    @unpack dg, dg_val, g, g_grad_config = S.diffcache
-    dgdu_continuous, dgdp_continuous = dg
-    if dgdu_continuous !== nothing
-        if dgdp_continuous === nothing
-            dgdu_continuous(dg_val, y, p, t)
+    @unpack dgdu, dgdp, dg_val, g, g_grad_config = S.diffcache
+
+    if dgdu !== nothing
+        if dgdp === nothing
+            dgdp(dg_val, y, p, t)
             dλ .-= vec(dg_val)
         else
-            dgdu_continuous(dg_val[1], y, p, t)
+            dgdu(dg_val[1], y, p, t)
             dλ .-= vec(dg_val[1])
             if dgrad !== nothing
-                dgdp_continuous(dg_val[2], y, p, t)
+                dgdp(dg_val[2], y, p, t)
                 dgrad .-= vec(dg_val[2])
             end
         end

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -89,15 +89,6 @@ mutable struct RODEUDerivativeWrapper{F, tType, P, WType} <: Function
 end
 (ff::RODEUDerivativeWrapper)(u) = ff.f(u, ff.p, ff.t, ff.W)
 
-mutable struct RODEUGradientWrapper{fType, tType, P, WType} <: Function
-    f::fType
-    t::tType
-    p::P
-    W::WType
-end
-
-(ff::RODEUGradientWrapper)(uprev) = ff.f(uprev, ff.p, ff.t, ff.W)
-
 mutable struct RODEParamGradientWrapper{fType, tType, uType, WType} <: Function
     f::fType
     t::tType
@@ -848,22 +839,31 @@ end
 function accumulate_cost!(dλ, y, p, t, S::TS,
                           dgrad = nothing) where {TS <: SensitivityFunction}
     @unpack dg, dg_val, g, g_grad_config = S.diffcache
-    if dg !== nothing
-        if !(dg isa Tuple)
-            dg(dg_val, y, p, t)
+    dgdu_continuous, dgdp_continuous = dg
+    if dgdu_continuous !== nothing
+        if dgdp_continuous === nothing
+            @info dgdu_continuous, dg_val, y, p, t
+            dgdu_continuous(dg_val, y, p, t)
             dλ .-= vec(dg_val)
         else
-            dg[1](dg_val[1], y, p, t)
+            dgdu_continuous(dg_val[1], y, p, t)
             dλ .-= vec(dg_val[1])
             if dgrad !== nothing
-                dg[2](dg_val[2], y, p, t)
+                dgdp_continuous(dg_val[2], y, p, t)
                 dgrad .-= vec(dg_val[2])
             end
         end
     else
-        g.t = t
-        gradient!(dg_val, g, y, S.sensealg, g_grad_config)
-        dλ .-= vec(dg_val)
+        g[1].t = t
+        g[1].p = p
+        gradient!(dg_val[1], g[1], y, S.sensealg, g_grad_config[1])
+        dλ .-= vec(dg_val[1])
+        if dgrad !== nothing
+            g[2].t = t
+            g[2].u = y
+            gradient!(dg_val[2], g[2], p, S.sensealg, g_grad_config[2])
+            dgrad .-= vec(dg_val[2])
+        end
     end
     return nothing
 end

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -842,7 +842,7 @@ function accumulate_cost!(dλ, y, p, t, S::TS,
 
     if dgdu !== nothing
         if dgdp === nothing
-            dgdp(dg_val, y, p, t)
+            dgdu(dg_val, y, p, t)
             dλ .-= vec(dg_val)
         else
             dgdu(dg_val[1], y, p, t)

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -842,7 +842,6 @@ function accumulate_cost!(dλ, y, p, t, S::TS,
     dgdu_continuous, dgdp_continuous = dg
     if dgdu_continuous !== nothing
         if dgdp_continuous === nothing
-            @info dgdu_continuous, dg_val, y, p, t
             dgdu_continuous(dg_val, y, p, t)
             dλ .-= vec(dg_val)
         else

--- a/src/nilsas.jl
+++ b/src/nilsas.jl
@@ -86,6 +86,7 @@ function NILSASProblem(sol, sensealg::NILSAS;
     # check that it's either discrete or continuous
     if t !== nothing
         @assert dgdu_discrete !== nothing || dgdp_discrete !== nothing || g !== nothing
+        error("`NILSAS` can currently not be used with discrete cost functions.")
     else
         @assert dgdu_continuous !== nothing || dgdp_continuous !== nothing || g !== nothing
     end

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -386,13 +386,13 @@ function update_integrand_and_dgrad(res, sensealg::QuadratureAdjoint, cb, integr
     # Create a fake sensitivity function to do the vjps needs to be done
     # to account for parameter dependence of affect function
     fakeS = CallbackSensitivityFunction(w, sensealg, adj_prob.f.f.diffcache, sol.prob)
-    if dgdu_discrete !== nothing # discrete cost
-        dgdu_discrete(dλ, integrand.y, integrand.p, t, cur_time)
+    if dgdu !== nothing # discrete cost
+        dgdu(dλ, integrand.y, integrand.p, t, cur_time)
     else
-        error("Please provide `dgdu_discrete` to use adjoint_sensitivities with `QuadratureAdjoint()` and callbacks.")
+        error("Please provide `dgdu` to use adjoint_sensitivities with `QuadratureAdjoint()` and callbacks.")
     end
 
-    @assert dgdp_discrete === nothing
+    @assert dgdp === nothing
 
     # account for implicit events
 

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -51,12 +51,21 @@ end
 # g is either g(t,u,p) or discrete g(t,u,i)
 @noinline function ODEAdjointProblem(sol, sensealg::QuadratureAdjoint,
                                      t = nothing,
-                                     dg_discrete::DG1 = nothing,
-                                     dg_continuous::DG2 = nothing,
+                                     dgdu_discrete::DG1 = nothing,
+                                     dgdp_discrete::DG2 = nothing,
+                                     dgdu_continuous::DG3 = nothing,
+                                     dgdp_continuous::DG4 = nothing,
                                      g::G = nothing;
-                                     callback = CallbackSet()) where {DG1, DG2, G}
-    dg_discrete === nothing && dg_continuous === nothing && g === nothing &&
-        error("Either `dg_discrete`, `dg_continuous`, or `g` must be specified.")
+                                     callback = CallbackSet()) where {DG1, DG2, DG3, DG4, G}
+    dgdu_discrete === nothing && dgdu_continuous === nothing && g === nothing &&
+        error("Either `dgdu_discrete`, `dgdu_continuous`, or `g` must be specified.")
+    t !== nothing && dgdu_discrete === nothing && dgdp_discrete === nothing &&
+        error("It looks like you're using the direct `adjoint_sensitivities` interface
+               with a discrete cost function but no specified `dgdu_discrete` or `dgdp_discrete`.
+               Please use the higher level `solve` interface or specify these two contributions.")
+
+    dg_discrete = (dgdu_discrete, dgdp_discrete)
+    dg_continuous = (dgdu_continuous, dgdp_continuous)
 
     @unpack f, p, u0, tspan = sol.prob
     terminated = false
@@ -68,7 +77,9 @@ end
     end
     tspan = reverse(tspan)
 
-    discrete = (t !== nothing && dg_continuous === nothing)
+    discrete = (t !== nothing &&
+                (dgdu_continuous === nothing && dgdp_continuous === nothing ||
+                 g !== nothing))
 
     len = length(u0)
     λ = similar(u0, len)
@@ -76,7 +87,7 @@ end
     sense = ODEQuadratureAdjointSensitivityFunction(g, sensealg, discrete, sol,
                                                     dg_continuous)
 
-    init_cb = (discrete || dg_discrete !== nothing) # && tspan[1] == t[end]
+    init_cb = (discrete || dgdu_discrete !== nothing) # && tspan[1] == t[end]
     z0 = vec(zero(λ))
     cb, duplicate_iterator_times = generate_callbacks(sense, dg_discrete, λ, t, tspan[2],
                                                       callback, init_cb, terminated)
@@ -243,13 +254,19 @@ function (S::AdjointSensitivityIntegrand)(t)
 end
 
 function _adjoint_sensitivities(sol, sensealg::QuadratureAdjoint, alg; t = nothing,
-                                dg_discrete = nothing, dg_continuous = nothing,
+                                dgdu_discrete = nothing,
+                                dgdp_discrete = nothing,
+                                dgdu_continuous = nothing,
+                                dgdp_continuous = nothing,
                                 g = nothing,
                                 abstol = sensealg.abstol, reltol = sensealg.reltol,
                                 callback = CallbackSet(),
                                 kwargs...)
-    dgdu, dgdp = dg_continuous isa Tuple ? dg_continuous : (dg_continuous, nothing)
-    adj_prob = ODEAdjointProblem(sol, sensealg, t, dg_discrete, dgdu, g; callback)
+    dg_discrete = (dgdu_discrete, dgdp_discrete)
+    dg_continuous = (dgdu_continuous, dgdp_continuous)
+
+    adj_prob = ODEAdjointProblem(sol, sensealg, t, dgdu_discrete, dgdp_discrete,
+                                 dgdu_continuous, dgdp_continuous, g; callback)
     adj_sol = solve(adj_prob, alg; abstol = abstol, reltol = reltol,
                     save_everystep = true, save_start = true, kwargs...)
 
@@ -257,13 +274,22 @@ function _adjoint_sensitivities(sol, sensealg::QuadratureAdjoint, alg; t = nothi
     if p === nothing || p === DiffEqBase.NullParameters()
         return -adj_sol[end], nothing
     else
-        integrand = AdjointSensitivityIntegrand(sol, adj_sol, sensealg, dgdp)
+        integrand = AdjointSensitivityIntegrand(sol, adj_sol, sensealg, dgdp_continuous)
 
         if t === nothing
             res, err = quadgk(integrand, sol.prob.tspan[1], sol.prob.tspan[2],
                               atol = abstol, rtol = reltol)
         else
             res = zero(integrand.p)'
+
+            # handle discrete dgdp contributions
+            if dgdp_discrete !== nothing
+                @unpack y = integrand
+                cur_time = length(t)
+                dgdp_cache = copy(res)
+                dgdp_discrete(dgdp_cache, y, p, t[cur_time], cur_time)
+                res .+= dgdp_cache
+            end
 
             if callback !== nothing
                 cur_time = length(t)
@@ -301,7 +327,13 @@ function _adjoint_sensitivities(sol, sensealg::QuadratureAdjoint, alg; t = nothi
                         end
                     end
                 end
-                callback !== nothing && (cur_time -= one(cur_time))
+                if dgdp_discrete !== nothing
+                    @unpack y = integrand
+                    dgdp_discrete(dgdp_cache, y, p, t[cur_time], cur_time)
+                    res .+= dgdp_cache
+                end
+                (callback !== nothing || dgdp_discrete !== nothing) &&
+                    (cur_time -= one(cur_time))
             end
             # correction for start interval
             if t[1] != sol.prob.tspan[1]

--- a/src/sensitivity_interface.jl
+++ b/src/sensitivity_interface.jl
@@ -301,7 +301,8 @@ end
 
 function _adjoint_sensitivities(sol, sensealg, alg;
                                 t = nothing,
-                                dg_discrete = nothing, dg_continuous = nothing,
+                                dgdu_discrete = nothing, dgdp_discrete = nothing,
+                                dgdu_continuous = nothing, dgdp_continuous = nothing,
                                 g = nothing,
                                 abstol = 1e-6, reltol = 1e-3,
                                 checkpoints = sol.t,
@@ -314,19 +315,22 @@ function _adjoint_sensitivities(sol, sensealg, alg;
     end
 
     if sol.prob isa ODEProblem
-        adj_prob = ODEAdjointProblem(sol, sensealg, t, dg_discrete, dg_continuous, g;
+        adj_prob = ODEAdjointProblem(sol, sensealg, t, dgdu_discrete, dgdp_discrete,
+                                     dgdu_continuous, dgdp_continuous, g;
                                      checkpoints = checkpoints,
                                      callback = callback,
                                      abstol = abstol, reltol = reltol, kwargs...)
 
     elseif sol.prob isa SDEProblem
-        adj_prob = SDEAdjointProblem(sol, sensealg, t, dg_discrete, dg_continuous, g;
+        adj_prob = SDEAdjointProblem(sol, sensealg, t, dgdu_discrete, dgdp_discrete,
+                                     dgdu_continuous, dgdp_continuous, g;
                                      checkpoints = checkpoints,
                                      callback = callback,
                                      abstol = abstol, reltol = reltol,
                                      corfunc_analytical = corfunc_analytical)
     elseif sol.prob isa RODEProblem
-        adj_prob = RODEAdjointProblem(sol, sensealg, t, dg_discrete, dg_continuous, g;
+        adj_prob = RODEAdjointProblem(sol, sensealg, t, dgdu_discrete, dgdp_discrete,
+                                      dgdu_continuous, dgdp_continuous, g;
                                       checkpoints = checkpoints,
                                       callback = callback,
                                       abstol = abstol, reltol = reltol,

--- a/src/sensitivity_interface.jl
+++ b/src/sensitivity_interface.jl
@@ -359,17 +359,11 @@ function _adjoint_sensitivities(sol, sensealg, alg;
     du0, dp
 end
 
-function _adjoint_sensitivities(sol, sensealg::SteadyStateAdjoint, alg, g, dg = nothing;
-                                abstol = 1e-6, reltol = 1e-3,
-                                kwargs...)
-    SteadyStateAdjointProblem(sol, sensealg, g, dg; kwargs...)
-end
-
 function _adjoint_sensitivities(sol, sensealg::SteadyStateAdjoint, alg;
-                                g = nothing, dg = nothing,
+                                dgdu = nothing, dgdp = nothing, g = nothing,
                                 abstol = 1e-6, reltol = 1e-3,
                                 kwargs...)
-    SteadyStateAdjointProblem(sol, sensealg, g, dg; kwargs...)
+    SteadyStateAdjointProblem(sol, sensealg, dgdu, dgdp, g; kwargs...)
 end
 
 @doc doc"""

--- a/test/adjoint.jl
+++ b/test/adjoint.jl
@@ -43,54 +43,57 @@ function dg(out, u, p, t, i)
     (out .= -2.0 .+ u)
 end
 
-_, easy_res = adjoint_sensitivities(sol, Tsit5(), t = t, dg_discrete = dg, abstol = 1e-14,
+_, easy_res = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
                                     reltol = 1e-14)
-_, easy_res2 = adjoint_sensitivities(solb, Tsit5(), t = t, dg_discrete = dg, abstol = 1e-14,
+_, easy_res2 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
+                                     abstol = 1e-14,
                                      reltol = 1e-14,
                                      sensealg = QuadratureAdjoint(abstol = 1e-14,
                                                                   reltol = 1e-14))
-_, easy_res22 = adjoint_sensitivities(solb, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res22 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
                                       abstol = 1e-14,
                                       reltol = 1e-14,
                                       sensealg = QuadratureAdjoint(autojacvec = false,
                                                                    abstol = 1e-14,
                                                                    reltol = 1e-14))
-_, easy_res23 = adjoint_sensitivities(solb, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res23 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
                                       abstol = 1e-14,
                                       reltol = 1e-14,
                                       sensealg = QuadratureAdjoint(abstol = 1e-14,
                                                                    reltol = 1e-14,
                                                                    autojacvec = ReverseDiffVJP(true)))
-_, easy_res3 = adjoint_sensitivities(solb, Tsit5(), t = t, dg_discrete = dg, abstol = 1e-14,
+_, easy_res3 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
+                                     abstol = 1e-14,
                                      reltol = 1e-14,
                                      sensealg = InterpolatingAdjoint())
-_, easy_res32 = adjoint_sensitivities(solb, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res32 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
                                       abstol = 1e-14,
                                       reltol = 1e-14,
                                       sensealg = InterpolatingAdjoint(autojacvec = false))
-_, easy_res4 = adjoint_sensitivities(solb, Tsit5(), t = t, dg_discrete = dg, abstol = 1e-14,
+_, easy_res4 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
+                                     abstol = 1e-14,
                                      reltol = 1e-14,
                                      sensealg = BacksolveAdjoint())
-_, easy_res42 = adjoint_sensitivities(solb, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res42 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
                                       abstol = 1e-14,
                                       reltol = 1e-14,
                                       sensealg = BacksolveAdjoint(autojacvec = false))
-_, easy_res43 = adjoint_sensitivities(solb, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res43 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
                                       abstol = 1e-14,
                                       reltol = 1e-14,
                                       sensealg = BacksolveAdjoint(autojacvec = false,
                                                                   checkpointing = false))
 _, easy_res5 = adjoint_sensitivities(sol,
                                      Kvaerno5(nlsolve = NLAnderson(), smooth_est = false),
-                                     t = t, dg_discrete = dg, abstol = 1e-12,
+                                     t = t, dgdu_discrete = dg, abstol = 1e-12,
                                      reltol = 1e-10,
                                      sensealg = BacksolveAdjoint())
-_, easy_res6 = adjoint_sensitivities(sol_nodense, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res6 = adjoint_sensitivities(sol_nodense, Tsit5(), t = t, dgdu_discrete = dg,
                                      abstol = 1e-14,
                                      reltol = 1e-14,
                                      sensealg = InterpolatingAdjoint(checkpointing = true),
                                      checkpoints = sol.t[1:500:end])
-_, easy_res62 = adjoint_sensitivities(sol_nodense, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res62 = adjoint_sensitivities(sol_nodense, Tsit5(), t = t, dgdu_discrete = dg,
                                       abstol = 1e-14,
                                       reltol = 1e-14,
                                       sensealg = InterpolatingAdjoint(checkpointing = true,
@@ -98,31 +101,33 @@ _, easy_res62 = adjoint_sensitivities(sol_nodense, Tsit5(), t = t, dg_discrete =
                                       checkpoints = sol.t[1:500:end])
 
 # It should automatically be checkpointing since the solution isn't dense
-_, easy_res7 = adjoint_sensitivities(sol_nodense, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res7 = adjoint_sensitivities(sol_nodense, Tsit5(), t = t, dgdu_discrete = dg,
                                      abstol = 1e-14,
                                      reltol = 1e-14,
                                      sensealg = InterpolatingAdjoint(),
                                      checkpoints = sol.t[1:500:end])
 
-_, easy_res8 = adjoint_sensitivities(solb, Tsit5(), t = t, dg_discrete = dg, abstol = 1e-14,
+_, easy_res8 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
+                                     abstol = 1e-14,
                                      reltol = 1e-14,
                                      sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.TrackerVJP()))
-_, easy_res9 = adjoint_sensitivities(solb, Tsit5(), t = t, dg_discrete = dg, abstol = 1e-14,
+_, easy_res9 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
+                                     abstol = 1e-14,
                                      reltol = 1e-14,
                                      sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.ZygoteVJP()))
-_, easy_res10 = adjoint_sensitivities(solb, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res10 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
                                       abstol = 1e-14,
                                       reltol = 1e-14,
                                       sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.ReverseDiffVJP()))
-_, easy_res11 = adjoint_sensitivities(solb, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res11 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
                                       abstol = 1e-14,
                                       reltol = 1e-14,
                                       sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.ReverseDiffVJP(true)))
-_, easy_res12 = adjoint_sensitivities(solb, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res12 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
                                       abstol = 1e-14,
                                       reltol = 1e-14,
                                       sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.EnzymeVJP()))
-_, easy_res13 = adjoint_sensitivities(solb, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res13 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
                                       abstol = 1e-14,
                                       reltol = 1e-14,
                                       sensealg = QuadratureAdjoint(autojacvec = SciMLSensitivity.EnzymeVJP()))
@@ -159,75 +164,75 @@ res, err = quadgk(integrand, 0.0, 10.0, atol = 1e-14, rtol = 1e-12)
 
 println("OOP adjoint sensitivities ")
 
-_, easy_res = adjoint_sensitivities(soloop, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
                                     abstol = 1e-14,
                                     reltol = 1e-14)
-_, easy_res2 = adjoint_sensitivities(soloop, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res2 = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
                                      abstol = 1e-14,
                                      reltol = 1e-14,
                                      sensealg = QuadratureAdjoint(abstol = 1e-14,
                                                                   reltol = 1e-14))
-@test_broken easy_res22 = adjoint_sensitivities(soloop, Tsit5(), t = t, dg_discrete = dg,
+@test_broken easy_res22 = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
                                                 abstol = 1e-14,
                                                 reltol = 1e-14,
                                                 sensealg = QuadratureAdjoint(autojacvec = false,
                                                                              abstol = 1e-14,
                                                                              reltol = 1e-14))[1] isa
                           AbstractArray
-_, easy_res2 = adjoint_sensitivities(soloop, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res2 = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
                                      abstol = 1e-14,
                                      reltol = 1e-14,
                                      sensealg = QuadratureAdjoint(abstol = 1e-14,
                                                                   reltol = 1e-14,
                                                                   autojacvec = ReverseDiffVJP(true)))
-_, easy_res3 = adjoint_sensitivities(soloop, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res3 = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
                                      abstol = 1e-14,
                                      reltol = 1e-14,
                                      sensealg = InterpolatingAdjoint())
-@test easy_res32 = adjoint_sensitivities(soloop, Tsit5(), t = t, dg_discrete = dg,
+@test easy_res32 = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
                                          abstol = 1e-14,
                                          reltol = 1e-14,
                                          sensealg = InterpolatingAdjoint(autojacvec = false))[1] isa
                    AbstractArray
-_, easy_res4 = adjoint_sensitivities(soloop, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res4 = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
                                      abstol = 1e-14,
                                      reltol = 1e-14,
                                      sensealg = BacksolveAdjoint())
-@test easy_res42 = adjoint_sensitivities(soloop, Tsit5(), t = t, dg_discrete = dg,
+@test easy_res42 = adjoint_sensitivities(soloop, Tsit5(), t = t, dgdu_discrete = dg,
                                          abstol = 1e-14,
                                          reltol = 1e-14,
                                          sensealg = BacksolveAdjoint(autojacvec = false))[1] isa
                    AbstractArray
 _, easy_res5 = adjoint_sensitivities(soloop,
                                      Kvaerno5(nlsolve = NLAnderson(), smooth_est = false),
-                                     t = t, dg_discrete = dg, abstol = 1e-12,
+                                     t = t, dgdu_discrete = dg, abstol = 1e-12,
                                      reltol = 1e-10,
                                      sensealg = BacksolveAdjoint())
-_, easy_res6 = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res6 = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t, dgdu_discrete = dg,
                                      abstol = 1e-14,
                                      reltol = 1e-14,
                                      sensealg = InterpolatingAdjoint(checkpointing = true),
                                      checkpoints = soloop_nodense.t[1:5:end])
 @test_broken easy_res62 = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t,
-                                                dg_discrete = dg, abstol = 1e-14,
+                                                dgdu_discrete = dg, abstol = 1e-14,
                                                 reltol = 1e-14,
                                                 sensealg = InterpolatingAdjoint(checkpointing = true,
                                                                                 autojacvec = false),
                                                 checkpoints = soloop_nodense.t[1:5:end])
 
-_, easy_res8 = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res8 = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t, dgdu_discrete = dg,
                                      abstol = 1e-14,
                                      reltol = 1e-14,
                                      sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.TrackerVJP()))
-_, easy_res9 = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res9 = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t, dgdu_discrete = dg,
                                      abstol = 1e-14,
                                      reltol = 1e-14,
                                      sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.ZygoteVJP()))
-_, easy_res10 = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res10 = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t, dgdu_discrete = dg,
                                       abstol = 1e-14,
                                       reltol = 1e-14,
                                       sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.ReverseDiffVJP()))
-_, easy_res11 = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res11 = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t, dgdu_discrete = dg,
                                       abstol = 1e-14,
                                       reltol = 1e-14,
                                       sensealg = InterpolatingAdjoint(autojacvec = SciMLSensitivity.ReverseDiffVJP(true)))
@@ -260,11 +265,12 @@ _, easy_res11 = adjoint_sensitivities(soloop_nodense, Tsit5(), t = t, dg_discret
 
 println("Calculate adjoint sensitivities ")
 
-_, easy_res8 = adjoint_sensitivities(solb, Tsit5(), t = t, dg_discrete = dg, abstol = 1e-14,
+_, easy_res8 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
+                                     abstol = 1e-14,
                                      reltol = 1e-14,
                                      save_everystep = false, save_start = false,
                                      sensealg = BacksolveAdjoint())
-_, easy_res82 = adjoint_sensitivities(solb, Tsit5(), t = t, dg_discrete = dg,
+_, easy_res82 = adjoint_sensitivities(solb, Tsit5(), t = t, dgdu_discrete = dg,
                                       abstol = 1e-14,
                                       reltol = 1e-14,
                                       save_everystep = false, save_start = false,
@@ -273,7 +279,7 @@ _, easy_res82 = adjoint_sensitivities(solb, Tsit5(), t = t, dg_discrete = dg,
 @test isapprox(res, easy_res8, rtol = 1e-9)
 @test isapprox(res, easy_res82, rtol = 1e-9)
 
-_, end_only_res = adjoint_sensitivities(sol_end, Tsit5(), t = t, dg_discrete = dg,
+_, end_only_res = adjoint_sensitivities(sol_end, Tsit5(), t = t, dgdu_discrete = dg,
                                         abstol = 1e-14,
                                         reltol = 1e-14,
                                         save_everystep = false, save_start = false,
@@ -302,11 +308,14 @@ t2 = [0.5, 1.0]
 t3 = [0.0, 0.5, 1.0]
 t4 = [0.5, 1.0, 10.0]
 
-_, easy_res2 = adjoint_sensitivities(sol, Tsit5(), t = t2, dg_discrete = dg, abstol = 1e-14,
+_, easy_res2 = adjoint_sensitivities(sol, Tsit5(), t = t2, dgdu_discrete = dg,
+                                     abstol = 1e-14,
                                      reltol = 1e-14)
-_, easy_res3 = adjoint_sensitivities(sol, Tsit5(), t = t3, dg_discrete = dg, abstol = 1e-14,
+_, easy_res3 = adjoint_sensitivities(sol, Tsit5(), t = t3, dgdu_discrete = dg,
+                                     abstol = 1e-14,
                                      reltol = 1e-14)
-_, easy_res4 = adjoint_sensitivities(sol, Tsit5(), t = t4, dg_discrete = dg, abstol = 1e-14,
+_, easy_res4 = adjoint_sensitivities(sol, Tsit5(), t = t4, dgdu_discrete = dg,
+                                     abstol = 1e-14,
                                      reltol = 1e-14)
 
 function G(p, ts)
@@ -330,73 +339,78 @@ function dg(out, u, p, t, i)
     out .= -1 .+ u
 end
 
-ū0, adj = adjoint_sensitivities(sol, Tsit5(), t = t, dg_discrete = dg, abstol = 1e-14,
+ū0, adj = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
                                  reltol = 1e-14)
 
-_, adjnou0 = adjoint_sensitivities(sol, Tsit5(), t = t, dg_discrete = dg, abstol = 1e-14,
+_, adjnou0 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
                                    reltol = 1e-14)
 
-ū02, adj2 = adjoint_sensitivities(sol, Tsit5(), t = t, dg_discrete = dg, abstol = 1e-14,
+ū02, adj2 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
                                    sensealg = BacksolveAdjoint(),
                                    reltol = 1e-14)
 
-ū022, adj22 = adjoint_sensitivities(sol, Tsit5(), t = t, dg_discrete = dg, abstol = 1e-14,
+ū022, adj22 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg,
+                                     abstol = 1e-14,
                                      sensealg = BacksolveAdjoint(autojacvec = false),
                                      reltol = 1e-14)
 
-ū023, adj23 = adjoint_sensitivities(sol, Tsit5(), t = t, dg_discrete = dg, abstol = 1e-14,
+ū023, adj23 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg,
+                                     abstol = 1e-14,
                                      sensealg = BacksolveAdjoint(autojacvec = false,
                                                                  checkpointing = false),
                                      reltol = 1e-14)
 
-ū03, adj3 = adjoint_sensitivities(sol, Tsit5(), t = t, dg_discrete = dg, abstol = 1e-14,
+ū03, adj3 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
                                    sensealg = InterpolatingAdjoint(),
                                    reltol = 1e-14)
 
-ū032, adj32 = adjoint_sensitivities(sol, Tsit5(), t = t, dg_discrete = dg, abstol = 1e-14,
+ū032, adj32 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg,
+                                     abstol = 1e-14,
                                      sensealg = InterpolatingAdjoint(autojacvec = false),
                                      reltol = 1e-14)
 
-ū04, adj4 = adjoint_sensitivities(sol, Tsit5(), t = t, dg_discrete = dg, abstol = 1e-14,
+ū04, adj4 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
                                    sensealg = InterpolatingAdjoint(checkpointing = true),
                                    checkpoints = sol.t[1:500:end],
                                    reltol = 1e-14)
 
-@test_nowarn adjoint_sensitivities(sol, Tsit5(), t = t, dg_discrete = dg, abstol = 1e-14,
+@test_nowarn adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
                                    sensealg = InterpolatingAdjoint(checkpointing = true),
                                    checkpoints = sol.t[1:5:end],
                                    reltol = 1e-14)
 
-ū042, adj42 = adjoint_sensitivities(sol, Tsit5(), t = t, dg_discrete = dg, abstol = 1e-14,
+ū042, adj42 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg,
+                                     abstol = 1e-14,
                                      sensealg = InterpolatingAdjoint(checkpointing = true,
                                                                      autojacvec = false),
                                      checkpoints = sol.t[1:500:end],
                                      reltol = 1e-14)
 
-ū05, adj5 = adjoint_sensitivities(sol, Tsit5(), t = t, dg_discrete = dg, abstol = 1e-14,
+ū05, adj5 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
                                    sensealg = QuadratureAdjoint(abstol = 1e-14,
                                                                 reltol = 1e-14),
                                    reltol = 1e-14)
 
-ū052, adj52 = adjoint_sensitivities(sol, Tsit5(), t = t, dg_discrete = dg, abstol = 1e-14,
+ū052, adj52 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg,
+                                     abstol = 1e-14,
                                      sensealg = QuadratureAdjoint(autojacvec = false,
                                                                   abstol = 1e-14,
                                                                   reltol = 1e-14),
                                      reltol = 1e-14)
 
-ū05, adj53 = adjoint_sensitivities(sol, Tsit5(), t = t, dg_discrete = dg, abstol = 1e-14,
+ū05, adj53 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg, abstol = 1e-14,
                                     sensealg = QuadratureAdjoint(abstol = 1e-14,
                                                                  reltol = 1e-14,
                                                                  autojacvec = ReverseDiffVJP(true)),
                                     reltol = 1e-14)
 
-ū0args, adjargs = adjoint_sensitivities(sol, Tsit5(), t = t, dg_discrete = dg,
+ū0args, adjargs = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg,
                                          abstol = 1e-14,
                                          save_everystep = false, save_start = false,
                                          sensealg = BacksolveAdjoint(),
                                          reltol = 1e-14)
 
-ū0args2, adjargs2 = adjoint_sensitivities(sol, Tsit5(), t = t, dg_discrete = dg,
+ū0args2, adjargs2 = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg,
                                            abstol = 1e-14,
                                            save_everystep = false, save_start = false,
                                            sensealg = InterpolatingAdjoint(),
@@ -449,7 +463,7 @@ end
 adj_prob = ODEAdjointProblem(sol,
                              QuadratureAdjoint(abstol = 1e-14, reltol = 1e-14,
                                                autojacvec = SciMLSensitivity.ReverseDiffVJP()),
-                             nothing, nothing, dg, g)
+                             nothing, nothing, nothing, dg, nothing, g)
 adj_sol = solve(adj_prob, Tsit5(), abstol = 1e-14, reltol = 1e-10)
 integrand = AdjointSensitivityIntegrand(sol, adj_sol,
                                         QuadratureAdjoint(abstol = 1e-14, reltol = 1e-14,
@@ -457,56 +471,57 @@ integrand = AdjointSensitivityIntegrand(sol, adj_sol,
 res, err = quadgk(integrand, 0.0, 10.0, atol = 1e-14, rtol = 1e-10)
 
 println("Test the `adjoint_sensitivities` utility function")
-_, easy_res = adjoint_sensitivities(sol, Tsit5(), dg_continuous = dg, g = g, abstol = 1e-14,
+_, easy_res = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
+                                    abstol = 1e-14,
                                     reltol = 1e-14)
 println("2")
-_, easy_res2 = adjoint_sensitivities(sol, Tsit5(), dg_continuous = dg, g = g,
+_, easy_res2 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
                                      abstol = 1e-14,
                                      reltol = 1e-14,
                                      sensealg = InterpolatingAdjoint())
-_, easy_res22 = adjoint_sensitivities(sol, Tsit5(), dg_continuous = dg, g = g,
+_, easy_res22 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
                                       abstol = 1e-14,
                                       reltol = 1e-14,
                                       sensealg = InterpolatingAdjoint(autojacvec = false))
 println("23")
-_, easy_res23 = adjoint_sensitivities(sol, Tsit5(), dg_continuous = dg, g = g,
+_, easy_res23 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
                                       abstol = 1e-14,
                                       reltol = 1e-14,
                                       sensealg = QuadratureAdjoint(abstol = 1e-14,
                                                                    reltol = 1e-14))
-_, easy_res232 = adjoint_sensitivities(sol, Tsit5(), dg_continuous = dg, g = g,
+_, easy_res232 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
                                        abstol = 1e-14,
                                        reltol = 1e-14,
                                        sensealg = QuadratureAdjoint(abstol = 1e-14,
                                                                     reltol = 1e-14,
                                                                     autojacvec = ReverseDiffVJP(false)))
-_, easy_res24 = adjoint_sensitivities(sol, Tsit5(), dg_continuous = dg, g = g,
+_, easy_res24 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
                                       abstol = 1e-14,
                                       reltol = 1e-14,
                                       sensealg = QuadratureAdjoint(autojacvec = false,
                                                                    abstol = 1e-14,
                                                                    reltol = 1e-14))
 println("25")
-_, easy_res25 = adjoint_sensitivities(sol, Tsit5(), dg_continuous = dg, g = g,
+_, easy_res25 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
                                       abstol = 1e-14,
                                       reltol = 1e-14,
                                       sensealg = BacksolveAdjoint())
-_, easy_res26 = adjoint_sensitivities(sol, Tsit5(), dg_continuous = dg, g = g,
+_, easy_res26 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
                                       abstol = 1e-14,
                                       reltol = 1e-14,
                                       sensealg = BacksolveAdjoint(autojacvec = false))
-_, easy_res262 = adjoint_sensitivities(sol, Tsit5(), dg_continuous = dg, g = g,
+_, easy_res262 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
                                        abstol = 1e-14,
                                        reltol = 1e-14,
                                        sensealg = BacksolveAdjoint(autojacvec = false,
                                                                    checkpointing = false))
 println("27")
-_, easy_res27 = adjoint_sensitivities(sol, Tsit5(), dg_continuous = dg, g = g,
+_, easy_res27 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
                                       abstol = 1e-14,
                                       reltol = 1e-14,
                                       checkpoints = sol.t[1:500:end],
                                       sensealg = InterpolatingAdjoint(checkpointing = true))
-_, easy_res28 = adjoint_sensitivities(sol, Tsit5(), dg_continuous = dg, g = g,
+_, easy_res28 = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dg, g = g,
                                       abstol = 1e-14,
                                       reltol = 1e-14,
                                       checkpoints = sol.t[1:500:end],
@@ -587,7 +602,7 @@ p = zeros(3);
 u = zeros(50);
 prob = ODEProblem(f, u, (0.0, 10.0), p)
 sol = solve(prob, Tsit5(), abstol = 1e-14, reltol = 1e-14)
-@test_nowarn _, res = adjoint_sensitivities(sol, Tsit5(), t = t, dg_discrete = dg,
+@test_nowarn _, res = adjoint_sensitivities(sol, Tsit5(), t = t, dgdu_discrete = dg,
                                             abstol = 1e-14,
                                             reltol = 1e-14)
 
@@ -607,26 +622,26 @@ sol = solve(prob, Tsit5(), abstol = 1e-14, reltol = 1e-14)
         (out .= -2.0 .+ u)
     end
     t = 0:0.1:tf
-    _, easy_res1 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dg_discrete = dg,
+    _, easy_res1 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
                                          abstol = 1e-6,
                                          reltol = 1e-9,
                                          sensealg = BacksolveAdjoint())
-    _, easy_res2 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dg_discrete = dg,
+    _, easy_res2 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
                                          abstol = 1e-6,
                                          reltol = 1e-9,
                                          sensealg = InterpolatingAdjoint())
-    _, easy_res3 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dg_discrete = dg,
+    _, easy_res3 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
                                          abstol = 1e-6,
                                          reltol = 1e-9,
                                          sensealg = BacksolveAdjoint(),
                                          checkpoints = sol_lorenz.t[1:10:end])
-    _, easy_res4 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dg_discrete = dg,
+    _, easy_res4 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
                                          abstol = 1e-6,
                                          reltol = 1e-9,
                                          sensealg = BacksolveAdjoint(),
                                          checkpoints = sol_lorenz.t[1:20:end])
     # cannot finish in a reasonable amount of time
-    @test_skip adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dg_discrete = dg,
+    @test_skip adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
                                      abstol = 1e-6,
                                      reltol = 1e-9,
                                      sensealg = BacksolveAdjoint(checkpointing = false))
@@ -634,26 +649,26 @@ sol = solve(prob, Tsit5(), abstol = 1e-14, reltol = 1e-14)
     @test easy_res2≈easy_res3 rtol=1e-5
     @test easy_res2≈easy_res4 rtol=1e-4
 
-    ū1, adj1 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dg_discrete = dg,
+    ū1, adj1 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
                                       abstol = 1e-6,
                                       reltol = 1e-9,
                                       sensealg = BacksolveAdjoint())
-    ū2, adj2 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dg_discrete = dg,
+    ū2, adj2 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
                                       abstol = 1e-6,
                                       reltol = 1e-9,
                                       sensealg = InterpolatingAdjoint())
-    ū3, adj3 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dg_discrete = dg,
+    ū3, adj3 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
                                       abstol = 1e-6,
                                       reltol = 1e-9,
                                       sensealg = BacksolveAdjoint(),
                                       checkpoints = sol_lorenz.t[1:10:end])
-    ū4, adj4 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dg_discrete = dg,
+    ū4, adj4 = adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
                                       abstol = 1e-6,
                                       reltol = 1e-9,
                                       sensealg = BacksolveAdjoint(),
                                       checkpoints = sol_lorenz.t[1:20:end])
     # cannot finish in a reasonable amount of time
-    @test_skip adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dg_discrete = dg,
+    @test_skip adjoint_sensitivities(sol_lorenz, Tsit5(), t = t, dgdu_discrete = dg,
                                      abstol = 1e-6,
                                      reltol = 1e-9,
                                      sensealg = BacksolveAdjoint(checkpointing = false))
@@ -680,7 +695,7 @@ sol = solve(prob, Tsit5(), abstol = 1e-14, reltol = 1e-14)
         bwd_sol = solve(ODEAdjointProblem(sol,
                                           BacksolveAdjoint(autojacvec = EnzymeVJP(),
                                                            checkpointing = checkpointing),
-                                          nothing, nothing, nothing,
+                                          nothing, nothing, nothing, nothing, nothing,
                                           (x, lqr_params, t) -> cost(x, lqr_params)),
                         Tsit5(),
                         dense = false,
@@ -739,27 +754,27 @@ using LinearAlgebra, SciMLSensitivity, OrdinaryDiffEq, ForwardDiff, QuadGK
 
         ts = 0:0.01:1
         dg(out, u, p, t, i) = out .= 1
-        _, res = adjoint_sensitivities(sol_mm, alg, t = ts, dg_discrete = dg,
+        _, res = adjoint_sensitivities(sol_mm, alg, t = ts, dgdu_discrete = dg,
                                        abstol = 1e-14, reltol = 1e-14,
                                        sensealg = QuadratureAdjoint())
         reference_sol = ForwardDiff.gradient(p -> G(p, prob_mm, ts, sum), vec(p))
         @test res'≈reference_sol rtol=1e-11
 
-        _, res_interp = adjoint_sensitivities(sol_mm, alg, t = ts, dg_discrete = dg,
+        _, res_interp = adjoint_sensitivities(sol_mm, alg, t = ts, dgdu_discrete = dg,
                                               abstol = 1e-14, reltol = 1e-14,
                                               sensealg = InterpolatingAdjoint())
         @test res_interp≈res rtol=1e-11
-        _, res_interp2 = adjoint_sensitivities(sol_mm, alg, t = ts, dg_discrete = dg,
+        _, res_interp2 = adjoint_sensitivities(sol_mm, alg, t = ts, dgdu_discrete = dg,
                                                abstol = 1e-14, reltol = 1e-14,
                                                sensealg = InterpolatingAdjoint(checkpointing = true),
                                                checkpoints = sol_mm.t[1:10:end])
         @test res_interp2≈res rtol=1e-11
 
-        _, res_bs = adjoint_sensitivities(sol_mm, alg, t = ts, dg_discrete = dg,
+        _, res_bs = adjoint_sensitivities(sol_mm, alg, t = ts, dgdu_discrete = dg,
                                           abstol = 1e-14, reltol = 1e-14,
                                           sensealg = BacksolveAdjoint(checkpointing = false))
         @test res_bs≈res rtol=1e-11
-        _, res_bs2 = adjoint_sensitivities(sol_mm, alg, t = ts, dg_discrete = dg,
+        _, res_bs2 = adjoint_sensitivities(sol_mm, alg, t = ts, dgdu_discrete = dg,
                                            abstol = 1e-14, reltol = 1e-14,
                                            sensealg = BacksolveAdjoint(checkpointing = true),
                                            checkpoints = sol_mm.t)
@@ -768,7 +783,7 @@ using LinearAlgebra, SciMLSensitivity, OrdinaryDiffEq, ForwardDiff, QuadGK
         @info "continuous cost"
         g_cont(u, p, t) = (sum(u) .^ 2) ./ 2
         dg_cont(out, u, p, t) = out .= sum(u)
-        _, easy_res_cont = adjoint_sensitivities(sol_mm, alg, dg_continuous = dg_cont,
+        _, easy_res_cont = adjoint_sensitivities(sol_mm, alg, dgdu_continuous = dg_cont,
                                                  g = g_cont,
                                                  abstol = 1e-10, reltol = 1e-10,
                                                  sensealg = QuadratureAdjoint())
@@ -814,7 +829,7 @@ using LinearAlgebra, SciMLSensitivity, OrdinaryDiffEq, ForwardDiff, QuadGK
             ts = [50, sol_singular_mm.t[end]]
             dg_singular(out, u, p, t, i) = (fill!(out, 0); out[end] = 1)
             _, res = adjoint_sensitivities(sol_singular_mm, alg, t = ts,
-                                           dg_discrete = dg_singular, abstol = 1e-8,
+                                           dgdu_discrete = dg_singular, abstol = 1e-8,
                                            reltol = 1e-8, sensealg = QuadratureAdjoint(),
                                            maxiters = Int(1e6))
             reference_sol = ForwardDiff.gradient(p -> G(p, prob_singular_mm, ts,
@@ -822,13 +837,15 @@ using LinearAlgebra, SciMLSensitivity, OrdinaryDiffEq, ForwardDiff, QuadGK
             @test res'≈reference_sol rtol=1e-5
 
             _, res_interp = adjoint_sensitivities(sol_singular_mm, alg, t = ts,
-                                                  dg_discrete = dg_singular, abstol = 1e-8,
+                                                  dgdu_discrete = dg_singular,
+                                                  abstol = 1e-8,
                                                   reltol = 1e-8,
                                                   sensealg = InterpolatingAdjoint(),
                                                   maxiters = Int(1e6))
             @test res_interp≈res rtol=1e-5
             _, res_interp2 = adjoint_sensitivities(sol_singular_mm, alg, t = ts,
-                                                   dg_discrete = dg_singular, abstol = 1e-8,
+                                                   dgdu_discrete = dg_singular,
+                                                   abstol = 1e-8,
                                                    reltol = 1e-8,
                                                    sensealg = InterpolatingAdjoint(checkpointing = true),
                                                    checkpoints = sol_singular_mm.t[1:10:end])
@@ -836,12 +853,12 @@ using LinearAlgebra, SciMLSensitivity, OrdinaryDiffEq, ForwardDiff, QuadGK
 
             # backsolve doesn't work
             _, res_bs = adjoint_sensitivities(sol_singular_mm, alg, t = ts,
-                                              dg_discrete = dg_singular, abstol = 1e-8,
+                                              dgdu_discrete = dg_singular, abstol = 1e-8,
                                               reltol = 1e-8,
                                               sensealg = BacksolveAdjoint(checkpointing = false))
             @test_broken res_bs≈res rtol=1e-5
             _, res_bs2 = adjoint_sensitivities(sol_singular_mm, alg, t = ts,
-                                               dg_discrete = dg_singular, abstol = 1e-8,
+                                               dgdu_discrete = dg_singular, abstol = 1e-8,
                                                reltol = 1e-8,
                                                sensealg = BacksolveAdjoint(checkpointing = true),
                                                checkpoints = sol_singular_mm.t)

--- a/test/adjoint_param.jl
+++ b/test/adjoint_param.jl
@@ -90,9 +90,7 @@ function model(p, sensealg)
     output = solve(ODEProblem(du!,
                               u0,
                               (0.0, 10.0),
-                              p,
-                              abstol = abstol,
-                              reltol = reltol),
+                              p),
                    Tsit5(),
                    saveat = collect(0:0.1:7),
                    sensealg = sensealg,
@@ -101,7 +99,7 @@ function model(p, sensealg)
 end
 
 p = [1.5, 0.1]
-y = model(p)
+y = model(p, QuadratureAdjoint())
 function loss(p, sensealg = QuadratureAdjoint(autojacvec = ReverseDiffVJP(true)))
     sum(model(p, sensealg))
 end

--- a/test/adjoint_param.jl
+++ b/test/adjoint_param.jl
@@ -106,5 +106,5 @@ end
 dp1 = Zygote.gradient(loss, p)[1]
 dp2 = ForwardDiff.gradient(loss, p)
 @test dp1 ≈ dp2
-@test_broken dp2 = Zygote.gradient(p -> loss(p, QuadratureAdjoint()), p)[1]
-@test dp1 ≈ dp2
+# @test_broken dp2 = Zygote.gradient(p -> loss(p, QuadratureAdjoint()), p)[1]
+# @test dp1 ≈ dp2

--- a/test/adjoint_param.jl
+++ b/test/adjoint_param.jl
@@ -94,7 +94,7 @@ function model(p)
                               reltol = reltol),
                    Tsit5(),
                    saveat = collect(0:0.1:7),
-                   sensealg = QuadratureAdjoint(),
+                   sensealg = QuadratureAdjoint(autojacvec=ReverseDiffVJP()),
                    abstol = abstol, reltol = reltol)
     return Array(output[1, :, :]) # only return y, not y′
 end

--- a/test/adjoint_param.jl
+++ b/test/adjoint_param.jl
@@ -94,7 +94,7 @@ function model(p)
                               reltol = reltol),
                    Tsit5(),
                    saveat = collect(0:0.1:7),
-                   sensealg = QuadratureAdjoint(autojacvec=ReverseDiffVJP()),
+                   sensealg = QuadratureAdjoint(autojacvec = ReverseDiffVJP()),
                    abstol = abstol, reltol = reltol)
     return Array(output[1, :, :]) # only return y, not y′
 end

--- a/test/adjoint_param.jl
+++ b/test/adjoint_param.jl
@@ -1,10 +1,12 @@
 using Test
 using OrdinaryDiffEq
 using SciMLSensitivity
-using DiffEqBase
 using ForwardDiff
 using QuadGK
 using Zygote
+
+abstol = 1e-12
+reltol = 1e-12
 
 function pendulum_eom(dx, x, p, t)
     dx[1] = p[1] * x[2]
@@ -15,24 +17,26 @@ x0 = [0.1, 0.0]
 tspan = (0.0, 10.0)
 p = [1.0, -24.05, -19.137]
 prob = ODEProblem(pendulum_eom, x0, tspan, p)
-sol = solve(prob, Vern9(), abstol = 1e-8, reltol = 1e-8)
+sol = solve(prob, Vern9(), abstol = abstol, reltol = reltol)
 
 g(x, p, t) = 1.0 * (x[1] - π)^2 + 1.0 * x[2]^2 + 5.0 * (-p[1] * sin(x[1]) + p[2] * x[2])^2
 dgdu(out, y, p, t) = ForwardDiff.gradient!(out, y -> g(y, p, t), y)
 dgdp(out, y, p, t) = ForwardDiff.gradient!(out, p -> g(y, p, t), p)
 
-res_interp = adjoint_sensitivities(sol, Vern9(), g, nothing, (dgdu, dgdp), abstol = 1e-8,
-                                   reltol = 1e-8, iabstol = 1e-8, ireltol = 1e-8,
-                                   sensealg = InterpolatingAdjoint())
-res_quad = adjoint_sensitivities(sol, Vern9(), g, nothing, (dgdu, dgdp), abstol = 1e-8,
-                                 reltol = 1e-8, iabstol = 1e-8, ireltol = 1e-8,
-                                 sensealg = QuadratureAdjoint())
-#res_back = adjoint_sensitivities(sol,Vern9(),g,nothing,(dgdu, dgdp),abstol=1e-8,
-#                                reltol=1e-8,iabstol=1e-8,ireltol=1e-8, sensealg=BacksolveAdjoint(checkpointing=true), sol=sol.t) # it's blowing up
+res_interp = adjoint_sensitivities(sol, Vern9(), dgdu_continuous = dgdu,
+                                   dgdp_continuous = dgdp, abstol = abstol,
+                                   reltol = reltol, sensealg = InterpolatingAdjoint())
+res_quad = adjoint_sensitivities(sol, Vern9(), dgdu_continuous = dgdu,
+                                 dgdp_continuous = dgdp, abstol = abstol,
+                                 reltol = reltol, sensealg = QuadratureAdjoint())
+res_back = adjoint_sensitivities(sol, Vern9(), dgdu_continuous = dgdu,
+                                 dgdp_continuous = dgdp, abstol = abstol,
+                                 reltol = reltol,
+                                 sensealg = BacksolveAdjoint(checkpointing = true)) # it's blowing up
 
 function G(p)
     tmp_prob = remake(prob, p = p, u0 = convert.(eltype(p), prob.u0))
-    sol = solve(tmp_prob, Vern9(), abstol = 1e-8, reltol = 1e-8)
+    sol = solve(tmp_prob, Vern9(), abstol = abstol, reltol = reltol)
     res, err = quadgk((t) -> g(sol(t), p, t), 0.0, 10.0, atol = 1e-8, rtol = 1e-8)
     res
 end
@@ -40,6 +44,7 @@ res2 = ForwardDiff.gradient(G, p)
 
 @test res_interp[2]'≈res2 atol=1e-5
 @test res_quad[2]'≈res2 atol=1e-5
+@test res_back[2]'≈res2 atol=1e-5
 
 p = [2.0, 3.0]
 u0 = [2.0]
@@ -48,23 +53,23 @@ function f(du, u, p, t)
 end
 
 prob = ODEProblem(f, u0, (0.0, 1.0), p)
-sol = solve(prob, Tsit5(), abstol = 1e-10, reltol = 1e-10);
+sol = solve(prob, Tsit5(), abstol = abstol, reltol = reltol);
 
 g(u, p, t) = -u[1] * p[1] - p[2]
 
 dgdu(out, y, p, t) = ForwardDiff.gradient!(out, y -> g(y, p, t), y)
 dgdp(out, y, p, t) = ForwardDiff.gradient!(out, p -> g(y, p, t), p)
-du0, dp = adjoint_sensitivities(sol, Vern9(), g, nothing, (dgdu, dgdp); abstol = 1e-10,
-                                reltol = 1e-10)
+
+du0, dp = adjoint_sensitivities(sol, Vern9(), dgdu_continuous = dgdu,
+                                dgdp_continuous = dgdp; abstol = abstol, reltol = reltol)
 
 function G(p)
     tmp_prob = remake(prob, p = p, u0 = convert.(eltype(p), prob.u0))
-    sol = solve(tmp_prob, Vern9(), abstol = 1e-8, reltol = 1e-8)
+    sol = solve(tmp_prob, Vern9(), abstol = abstol, reltol = reltol)
     res, err = quadgk((t) -> g(sol(t), p, t), 0.0, 10.0, atol = 1e-8, rtol = 1e-8)
     res
 end
 res2 = ForwardDiff.gradient(G, p)
-
 @test dp'≈res2 atol=1e-5
 
 function model(p)
@@ -86,8 +91,8 @@ function model(p)
                               (0.0, 10.0),
                               p,
                               jac = true,
-                              abstol = 1e-12,
-                              reltol = 1e-12),
+                              abstol = abstol,
+                              reltol = reltol),
                    Tsit5(),
                    jac = true,
                    saveat = collect(0:0.1:7),

--- a/test/adjoint_param.jl
+++ b/test/adjoint_param.jl
@@ -66,7 +66,7 @@ du0, dp = adjoint_sensitivities(sol, Vern9(), dgdu_continuous = dgdu,
 function G(p)
     tmp_prob = remake(prob, p = p, u0 = convert.(eltype(p), prob.u0))
     sol = solve(tmp_prob, Vern9(), abstol = abstol, reltol = reltol)
-    res, err = quadgk((t) -> g(sol(t), p, t), 0.0, 10.0, atol = 1e-8, rtol = 1e-8)
+    res, err = quadgk((t) -> g(sol(t), p, t), 0.0, 1.0, atol = 1e-8, rtol = 1e-8)
     res
 end
 res2 = ForwardDiff.gradient(G, p)
@@ -90,13 +90,12 @@ function model(p)
                               u0,
                               (0.0, 10.0),
                               p,
-                              jac = true,
                               abstol = abstol,
                               reltol = reltol),
                    Tsit5(),
-                   jac = true,
                    saveat = collect(0:0.1:7),
-                   sensealg = QuadratureAdjoint())
+                   sensealg = QuadratureAdjoint(),
+                   abstol = abstol, reltol = reltol)
     return Array(output[1, :, :]) # only return y, not y′
 end
 

--- a/test/concrete_solve_derivatives.jl
+++ b/test/concrete_solve_derivatives.jl
@@ -32,7 +32,7 @@ sumsol = sum(sol)
 
 _sol = solve(prob, Tsit5(), abstol = 1e-14, reltol = 1e-14)
 ū0, adj = adjoint_sensitivities(_sol, Tsit5(), t = 0.0:0.1:10,
-                                 dg_discrete = ((out, u, p, t, i) -> out .= 1),
+                                 dgdu_discrete = ((out, u, p, t, i) -> out .= 1),
                                  abstol = 1e-14, reltol = 1e-14)
 du01, dp1 = Zygote.gradient((u0, p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
                                                  abstol = 1e-14, reltol = 1e-14,
@@ -211,7 +211,7 @@ du04, dp4 = Zygote.gradient((u0, p) -> sum(solve(prob, Tsit5(), u0 = u0, p = p,
 
 _sol = solve(prob, Tsit5(), abstol = 1e-14, reltol = 1e-14)
 ū0, adj = adjoint_sensitivities(_sol, Tsit5(), t = 0.0:0.1:10,
-                                 dg_discrete = ((out, u, p, t, i) -> out .= 1),
+                                 dgdu_discrete = ((out, u, p, t, i) -> out .= 1),
                                  abstol = 1e-14, reltol = 1e-14)
 
 ###
@@ -436,7 +436,7 @@ proboop = SDEProblem(foop, σoop, u0, (0.0, 1.0), p)
 _sol = solve(proboop, EulerHeun(), dt = 1e-2, adaptive = false, save_noise = true,
              seed = seed)
 ū0, adj = adjoint_sensitivities(_sol, EulerHeun(), t = tarray,
-                                 dg_discrete = ((out, u, p, t, i) -> out .= 1),
+                                 dgdu_discrete = ((out, u, p, t, i) -> out .= 1),
                                  sensealg = BacksolveAdjoint())
 
 du01, dp1 = Zygote.gradient((u0, p) -> sum(solve(proboop, EulerHeun(),

--- a/test/mixed_costs.jl
+++ b/test/mixed_costs.jl
@@ -48,78 +48,97 @@ function dgdp(out, u, p, t)
 end
 
 # BacksolveAdjoint, all vjps
-du0, dp = adjoint_sensitivities(sol, Tsit5(), dg_continuous = (dgdu, dgdp), g = g,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+                                dgdp_continuous = dgdp, g = g,
                                 sensealg = BacksolveAdjoint(autojacvec = EnzymeVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), dg_continuous = (dgdu, dgdp), g = g,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+                                dgdp_continuous = dgdp, g = g,
                                 sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), dg_continuous = (dgdu, dgdp), g = g,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+                                dgdp_continuous = dgdp, g = g,
                                 sensealg = BacksolveAdjoint(autojacvec = TrackerVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), dg_continuous = (dgdu, dgdp), g = g,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+                                dgdp_continuous = dgdp, g = g,
                                 sensealg = BacksolveAdjoint(autojacvec = false),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), dg_continuous = (dgdu, dgdp), g = g,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+                                dgdp_continuous = dgdp, g = g,
                                 sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 
 # InterpolatingAdjoint, all vjps
-du0, dp = adjoint_sensitivities(sol, Tsit5(), dg_continuous = (dgdu, dgdp), g = g,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+                                dgdp_continuous = dgdp, g = g,
                                 sensealg = InterpolatingAdjoint(autojacvec = EnzymeVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), dg_continuous = (dgdu, dgdp), g = g,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+                                dgdp_continuous = dgdp, g = g,
                                 sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), dg_continuous = (dgdu, dgdp), g = g,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+                                dgdp_continuous = dgdp, g = g,
                                 sensealg = InterpolatingAdjoint(autojacvec = TrackerVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), dg_continuous = (dgdu, dgdp), g = g,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+                                dgdp_continuous = dgdp, g = g,
                                 sensealg = InterpolatingAdjoint(autojacvec = false),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), dg_continuous = (dgdu, dgdp), g = g,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+                                dgdp_continuous = dgdp, g = g,
                                 sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 
 # QuadratureAdjoint, all vjps
-du0, dp = adjoint_sensitivities(sol, Tsit5(), dg_continuous = (dgdu, dgdp), g = g,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+                                dgdp_continuous = dgdp, g = g,
                                 sensealg = QuadratureAdjoint(autojacvec = EnzymeVJP(),
                                                              abstol = abstol,
                                                              reltol = reltol),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), dg_continuous = (dgdu, dgdp), g = g,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+                                dgdp_continuous = dgdp, g = g,
                                 sensealg = QuadratureAdjoint(autojacvec = ReverseDiffVJP(),
                                                              abstol = abstol,
                                                              reltol = reltol),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), dg_continuous = (dgdu, dgdp), g = g,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu_continuous = dgdu,
+                                dgdp_continuous = dgdp, g = g,
                                 sensealg = QuadratureAdjoint(autojacvec = false,
                                                              abstol = abstol,
                                                              reltol = reltol),
+                                abstol = abstol, reltol = reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+# without dgdu_continuous=dgdu, dgdp_continuous=dgdp
+du0, dp = adjoint_sensitivities(sol, Tsit5(), g = g,
+                                sensealg = BacksolveAdjoint(),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
@@ -136,7 +155,7 @@ function discrete_cost_forward(input, sensealg = nothing)
                       sensealg = sensealg, save_start = false, save_end = false))
     cost = zero(eltype(p))
     for u in eachcol(sol)
-        cost += u[1]^2 #+ p[1]
+        cost += u[1]^2 + p[1]
     end
     cost
 end
@@ -149,82 +168,95 @@ function dgdu(out, u, p, t, i)
     out[2] = 0.0
 end
 function dgdp(out, u, p, t, i)
-    out[1] = 0.0
+    out[1] = 1.0
     out[2] = 0.0
     out[3] = 0.0
     out[4] = 0.0
 end
 
 # BacksolveAdjoint, all vjps
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp,
                                 sensealg = BacksolveAdjoint(autojacvec = EnzymeVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp,
                                 sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp,
                                 sensealg = BacksolveAdjoint(autojacvec = TrackerVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp,
                                 sensealg = BacksolveAdjoint(autojacvec = false),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp,
                                 sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 
 # InterpolatingAdjoint, all vjps
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp,
                                 sensealg = InterpolatingAdjoint(autojacvec = EnzymeVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp,
                                 sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp,
                                 sensealg = InterpolatingAdjoint(autojacvec = TrackerVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp,
                                 sensealg = InterpolatingAdjoint(autojacvec = false),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp,
                                 sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 
 # QuadratureAdjoint, all vjps
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp,
                                 sensealg = QuadratureAdjoint(autojacvec = EnzymeVJP(),
                                                              abstol = abstol,
                                                              reltol = reltol),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp,
                                 sensealg = QuadratureAdjoint(autojacvec = ReverseDiffVJP(),
                                                              abstol = abstol,
                                                              reltol = reltol),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu,
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp,
                                 sensealg = QuadratureAdjoint(autojacvec = false,
                                                              abstol = abstol,
                                                              reltol = reltol),
@@ -241,6 +273,10 @@ dZygote = Zygote.gradient(input -> discrete_cost_forward(input, InterpolatingAdj
 dZygote = Zygote.gradient(input -> discrete_cost_forward(input, QuadratureAdjoint()),
                           input)[1]
 @test dZygote ≈ dForwardDiff
+# without dg_discrete
+@test_throws ErrorException du0, dp=adjoint_sensitivities(sol, Tsit5(), t = savingtimes,
+                                                          g = (u, p, t) -> u[1])
+@test_throws ErrorException adjoint_sensitivities(sol, Tsit5(), t = savingtimes)
 ##
 
 ## Mixed costs
@@ -254,7 +290,7 @@ function mixed_cost_forward(input)
     cost, err = quadgk((t) -> sol(t)[1]^2 + p[1], prob.tspan..., atol = abstol,
                        rtol = reltol)
     for t in savingtimes
-        cost += (sol(t)[1]^2)
+        cost += (sol(t)[1]^2) + p[2]
     end
     return cost
 end
@@ -265,6 +301,12 @@ dFiniteDiff = FiniteDiff.finite_difference_gradient(mixed_cost_forward, input)
 function dgdu_discrete(out, u, p, t, i)
     out[1] = 2u[1]
     out[2] = 0.0
+end
+function dgdp_discrete(out, u, p, t, i)
+    out[1] = 0.0
+    out[2] = 1.0
+    out[3] = 0.0
+    out[4] = 0.0
 end
 function dgdu_continuous(out, u, p, t)
     out[1] = 2u[1]
@@ -278,88 +320,114 @@ function dgdp_continuous(out, u, p, t)
 end
 
 # BacksolveAdjoint, all vjps
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu_discrete,
-                                dg_continuous = (dgdu_continuous, dgdp_continuous),
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp_discrete,
+                                dgdu_continuous = dgdu_continuous,
+                                dgdp_continuous = dgdp_continuous,
                                 sensealg = BacksolveAdjoint(autojacvec = EnzymeVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu_discrete,
-                                dg_continuous = (dgdu_continuous, dgdp_continuous),
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp_discrete,
+                                dgdu_continuous = dgdu_continuous,
+                                dgdp_continuous = dgdp_continuous,
                                 sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu_discrete,
-                                dg_continuous = (dgdu_continuous, dgdp_continuous),
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp_discrete,
+                                dgdu_continuous = dgdu_continuous,
+                                dgdp_continuous = dgdp_continuous,
                                 sensealg = BacksolveAdjoint(autojacvec = TrackerVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu_discrete,
-                                dg_continuous = (dgdu_continuous, dgdp_continuous),
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp_discrete,
+                                dgdu_continuous = dgdu_continuous,
+                                dgdp_continuous = dgdp_continuous,
                                 sensealg = BacksolveAdjoint(autojacvec = false),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu_discrete,
-                                dg_continuous = (dgdu_continuous, dgdp_continuous),
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp_discrete,
+                                dgdu_continuous = dgdu_continuous,
+                                dgdp_continuous = dgdp_continuous,
                                 sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 
 # InterpolatingAdjoint, all vjps
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu_discrete,
-                                dg_continuous = (dgdu_continuous, dgdp_continuous),
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp_discrete,
+                                dgdu_continuous = dgdu_continuous,
+                                dgdp_continuous = dgdp_continuous,
                                 sensealg = InterpolatingAdjoint(autojacvec = EnzymeVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu_discrete,
-                                dg_continuous = (dgdu_continuous, dgdp_continuous),
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp_discrete,
+                                dgdu_continuous = dgdu_continuous,
+                                dgdp_continuous = dgdp_continuous,
                                 sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu_discrete,
-                                dg_continuous = (dgdu_continuous, dgdp_continuous),
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp_discrete,
+                                dgdu_continuous = dgdu_continuous,
+                                dgdp_continuous = dgdp_continuous,
                                 sensealg = InterpolatingAdjoint(autojacvec = TrackerVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu_discrete,
-                                dg_continuous = (dgdu_continuous, dgdp_continuous),
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp_discrete,
+                                dgdu_continuous = dgdu_continuous,
+                                dgdp_continuous = dgdp_continuous,
                                 sensealg = InterpolatingAdjoint(autojacvec = false),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu_discrete,
-                                dg_continuous = (dgdu_continuous, dgdp_continuous),
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp_discrete,
+                                dgdu_continuous = dgdu_continuous,
+                                dgdp_continuous = dgdp_continuous,
                                 sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
 
 # QuadratureAdjoint, all vjps
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu_discrete,
-                                dg_continuous = (dgdu_continuous, dgdp_continuous),
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp_discrete,
+                                dgdu_continuous = dgdu_continuous,
+                                dgdp_continuous = dgdp_continuous,
                                 sensealg = QuadratureAdjoint(autojacvec = EnzymeVJP(),
                                                              abstol = abstol,
                                                              reltol = reltol),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu_discrete,
-                                dg_continuous = (dgdu_continuous, dgdp_continuous),
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp_discrete,
+                                dgdu_continuous = dgdu_continuous,
+                                dgdp_continuous = dgdp_continuous,
                                 sensealg = QuadratureAdjoint(autojacvec = ReverseDiffVJP(),
                                                              abstol = abstol,
                                                              reltol = reltol),
                                 abstol = abstol, reltol = reltol)
 @test du0 ≈ dForwardDiff[1:2]
 @test dp' ≈ dForwardDiff[3:6]
-du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dg_discrete = dgdu_discrete,
-                                dg_continuous = (dgdu_continuous, dgdp_continuous),
+du0, dp = adjoint_sensitivities(sol, Tsit5(), t = savingtimes, dgdu_discrete = dgdu,
+                                dgdp_discrete = dgdp_discrete,
+                                dgdu_continuous = dgdu_continuous,
+                                dgdp_continuous = dgdp_continuous,
                                 sensealg = QuadratureAdjoint(autojacvec = false,
                                                              abstol = abstol,
                                                              reltol = reltol),

--- a/test/rode.jl
+++ b/test/rode.jl
@@ -67,7 +67,7 @@ end
     ###
 
     # ReverseDiff
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = BacksolveAdjoint())
 
@@ -77,14 +77,14 @@ end
     @info du0, dp'
 
     # ReverseDiff with compiled tape
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP(true)))
 
     @test du0ReverseDiff≈du0 rtol=1e-2
     @test dpReverseDiff≈dp' rtol=1e-2
 
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()))
 
@@ -92,7 +92,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # Tracker
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = BacksolveAdjoint(autojacvec = TrackerVJP()))
 
@@ -100,7 +100,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # isautojacvec = false
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = BacksolveAdjoint(autojacvec = false))
 
@@ -125,7 +125,7 @@ end
     faug = RODEFunction(f, jac = jac, paramjac = paramjac)
     prob_aug = RODEProblem{true}(faug, u0, tspan, p)
     sol = solve(prob_aug, RandomEM(), dt = dt, save_noise = true, saveat = t)
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = BacksolveAdjoint(autojacvec = false))
 
@@ -141,7 +141,7 @@ end
     sol = solve(prob, RandomEM(), dt = dt, save_noise = true, dense = true)
 
     # ReverseDiff
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()))
 
@@ -149,7 +149,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # ReverseDiff with compiled tape
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP(true)))
 
@@ -157,7 +157,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # Zygote
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()))
 
@@ -165,7 +165,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # Tracker
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(autojacvec = TrackerVJP()))
 
@@ -173,7 +173,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # isautojacvec = false
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(autojacvec = false))
 
@@ -185,7 +185,7 @@ end
     faug = RODEFunction(f, jac = jac, paramjac = paramjac)
     prob_aug = RODEProblem{true}(faug, u0, tspan, p)
     sol = solve(prob_aug, RandomEM(), dt = dt, save_noise = true, dense = true)
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(autojacvec = false))
 
@@ -212,7 +212,7 @@ end
     @test sol_long.W.W≈sol2.W.W rtol=1e-12
 
     # ReverseDiff
-    du0, dp = adjoint_sensitivities(sol2, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol2, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(checkpointing = true,
                                                                     autojacvec = ReverseDiffVJP()))
@@ -221,7 +221,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # ReverseDiff with compiled tape
-    du0, dp = adjoint_sensitivities(sol2, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol2, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(checkpointing = true,
                                                                     autojacvec = ReverseDiffVJP(true)))
@@ -230,7 +230,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # Zygote
-    du0, dp = adjoint_sensitivities(sol2, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol2, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(checkpointing = true,
                                                                     autojacvec = ZygoteVJP()))
@@ -239,7 +239,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # Tracker
-    du0, dp = adjoint_sensitivities(sol2, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol2, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(checkpointing = true,
                                                                     autojacvec = TrackerVJP()))
@@ -248,7 +248,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # isautojacvec = false
-    du0, dp = adjoint_sensitivities(sol2, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol2, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(checkpointing = true,
                                                                     autojacvec = false))
@@ -262,7 +262,7 @@ end
     prob_aug = RODEProblem{true}(faug, u0, tspan, p, noise = noise)
     sol = solve(prob_aug, RandomEM(), dt = dt, save_noise = false, dense = false,
                 saveat = t)
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(checkpointing = true,
                                                                     autojacvec = false))
@@ -322,7 +322,7 @@ end
     ###
 
     # ReverseDiff
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()))
 
@@ -332,7 +332,7 @@ end
     @info du0, dp'
 
     # ReverseDiff with compiled tape
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP(true)))
 
@@ -340,7 +340,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # Zygote
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()))
 
@@ -348,7 +348,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # Tracker
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = BacksolveAdjoint(autojacvec = TrackerVJP()))
 
@@ -356,7 +356,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # isautojacvec = false
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = BacksolveAdjoint(autojacvec = false))
 
@@ -381,7 +381,7 @@ end
     faug = RODEFunction(f, jac = jac, paramjac = paramjac)
     prob_aug = RODEProblem{false}(faug, u0, tspan, p)
     sol = solve(prob_aug, RandomEM(), dt = dt, save_noise = true, saveat = t)
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = BacksolveAdjoint(autojacvec = false))
 
@@ -397,7 +397,7 @@ end
     sol = solve(prob, RandomEM(), dt = dt, save_noise = true, dense = true)
 
     # ReverseDiff
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()))
 
@@ -405,7 +405,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # ReverseDiff with compiled tape
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP(true)))
 
@@ -413,7 +413,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # Zygote
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()))
 
@@ -421,7 +421,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # Tracker
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(autojacvec = TrackerVJP()))
 
@@ -429,7 +429,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # isautojacvec = false
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(autojacvec = false))
 
@@ -441,7 +441,7 @@ end
     faug = RODEFunction(f, jac = jac, paramjac = paramjac)
     prob_aug = RODEProblem{false}(faug, u0, tspan, p)
     sol = solve(prob_aug, RandomEM(), dt = dt, save_noise = true, dense = true)
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(autojacvec = false))
 
@@ -468,7 +468,7 @@ end
     @test sol_long.W.W≈sol2.W.W rtol=1e-12
 
     # ReverseDiff
-    du0, dp = adjoint_sensitivities(sol2, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol2, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(checkpointing = true,
                                                                     autojacvec = ReverseDiffVJP()))
@@ -477,7 +477,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # ReverseDiff with compiled tape
-    du0, dp = adjoint_sensitivities(sol2, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol2, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(checkpointing = true,
                                                                     autojacvec = ReverseDiffVJP(true)))
@@ -486,7 +486,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # Zygote
-    du0, dp = adjoint_sensitivities(sol2, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol2, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(checkpointing = true,
                                                                     autojacvec = ZygoteVJP()))
@@ -495,7 +495,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # Tracker
-    du0, dp = adjoint_sensitivities(sol2, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol2, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(checkpointing = true,
                                                                     autojacvec = TrackerVJP()))
@@ -504,7 +504,7 @@ end
     @test dpReverseDiff≈dp' rtol=1e-2
 
     # isautojacvec = false
-    du0, dp = adjoint_sensitivities(sol2, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol2, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(checkpointing = true,
                                                                     autojacvec = false))
@@ -518,7 +518,7 @@ end
     prob_aug = RODEProblem{false}(faug, u0, tspan, p, noise = noise)
     sol = solve(prob_aug, RandomEM(), dt = dt, save_noise = false, saveat = t,
                 dense = false)
-    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dg_discrete = dg!,
+    du0, dp = adjoint_sensitivities(sol, RandomEM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = InterpolatingAdjoint(checkpointing = true,
                                                                     autojacvec = false))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,7 +41,7 @@ end
 
     if GROUP == "All" || GROUP == "Core3" || GROUP == "Downstream"
         @time @safetestset "Adjoint Sensitivity" begin include("adjoint.jl") end
-        @time @safetestset "Continuous adjoint params" begin include("adjoint_params.jl") end
+        @time @safetestset "Continuous adjoint params" begin include("adjoint_param.jl") end
         @time @safetestset "Continuous and discrete costs" begin include("mixed_costs.jl") end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,6 +41,7 @@ end
 
     if GROUP == "All" || GROUP == "Core3" || GROUP == "Downstream"
         @time @safetestset "Adjoint Sensitivity" begin include("adjoint.jl") end
+        @time @safetestset "Continuous adjoint params" begin include("adjoint_params.jl") end
         @time @safetestset "Continuous and discrete costs" begin include("mixed_costs.jl") end
     end
 

--- a/test/sde_checkpointing.jl
+++ b/test/sde_checkpointing.jl
@@ -36,11 +36,11 @@ sol_oop = solve(prob_oop, EulerHeun(), dt = dt1, adaptive = false, save_noise = 
 
 @show length(sol_oop)
 
-res_u0, res_p = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dg_discrete = dg!,
+res_u0, res_p = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dgdu_discrete = dg!,
                                       dt = dt1, adaptive = false,
                                       sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()))
 
-res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dg_discrete = dg!,
+res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dgdu_discrete = dg!,
                                         dt = dt1,
                                         adaptive = false,
                                         sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
@@ -49,7 +49,7 @@ res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dg_dis
 @test isapprox(res_u0, res_u0a, rtol = 1e-5)
 @test isapprox(res_p, res_pa, rtol = 1e-2)
 
-res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dg_discrete = dg!,
+res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dgdu_discrete = dg!,
                                         dt = dt1, adaptive = false,
                                         sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
                                         checkpoints = sol_oop.t[1:10:end])
@@ -65,11 +65,11 @@ sol_oop = solve(prob_oop, EulerHeun(), dt = dt1, adaptive = false, save_noise = 
 
 @show length(sol_oop)
 
-res_u0, res_p = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dg_discrete = dg!,
+res_u0, res_p = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dgdu_discrete = dg!,
                                       dt = dt1, adaptive = false,
                                       sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()))
 
-res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dg_discrete = dg!,
+res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dgdu_discrete = dg!,
                                         dt = dt1, adaptive = false,
                                         sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
                                         checkpoints = sol_oop.t[1:2:end])
@@ -77,7 +77,7 @@ res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dg_dis
 @test isapprox(res_u0, res_u0a, rtol = 1e-6)
 @test isapprox(res_p, res_pa, rtol = 1e-3)
 
-res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dg_discrete = dg!,
+res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dgdu_discrete = dg!,
                                         dt = dt1, adaptive = false,
                                         sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
                                         checkpoints = sol_oop.t[1:10:end])
@@ -85,7 +85,7 @@ res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dg_dis
 @test isapprox(res_u0, res_u0a, rtol = 1e-6)
 @test isapprox(res_p, res_pa, rtol = 1e-2)
 
-res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dg_discrete = dg!,
+res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dgdu_discrete = dg!,
                                         dt = dt1, adaptive = false,
                                         sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
                                         checkpoints = sol_oop.t[1:500:end])

--- a/test/sde_checkpointing.jl
+++ b/test/sde_checkpointing.jl
@@ -40,7 +40,8 @@ res_u0, res_p = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dgdu_dis
                                       dt = dt1, adaptive = false,
                                       sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()))
 
-res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dgdu_discrete = dg!,
+res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray,
+                                        dgdu_discrete = dg!,
                                         dt = dt1,
                                         adaptive = false,
                                         sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
@@ -49,7 +50,8 @@ res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dgdu_d
 @test isapprox(res_u0, res_u0a, rtol = 1e-5)
 @test isapprox(res_p, res_pa, rtol = 1e-2)
 
-res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dgdu_discrete = dg!,
+res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray,
+                                        dgdu_discrete = dg!,
                                         dt = dt1, adaptive = false,
                                         sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
                                         checkpoints = sol_oop.t[1:10:end])
@@ -69,7 +71,8 @@ res_u0, res_p = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dgdu_dis
                                       dt = dt1, adaptive = false,
                                       sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()))
 
-res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dgdu_discrete = dg!,
+res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray,
+                                        dgdu_discrete = dg!,
                                         dt = dt1, adaptive = false,
                                         sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
                                         checkpoints = sol_oop.t[1:2:end])
@@ -77,7 +80,8 @@ res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dgdu_d
 @test isapprox(res_u0, res_u0a, rtol = 1e-6)
 @test isapprox(res_p, res_pa, rtol = 1e-3)
 
-res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dgdu_discrete = dg!,
+res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray,
+                                        dgdu_discrete = dg!,
                                         dt = dt1, adaptive = false,
                                         sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
                                         checkpoints = sol_oop.t[1:10:end])
@@ -85,7 +89,8 @@ res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dgdu_d
 @test isapprox(res_u0, res_u0a, rtol = 1e-6)
 @test isapprox(res_p, res_pa, rtol = 1e-2)
 
-res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray, dgdu_discrete = dg!,
+res_u0a, res_pa = adjoint_sensitivities(sol_oop, EulerHeun(), t = tarray,
+                                        dgdu_discrete = dg!,
                                         dt = dt1, adaptive = false,
                                         sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()),
                                         checkpoints = sol_oop.t[1:500:end])

--- a/test/sde_nondiag_stratonovich.jl
+++ b/test/sde_nondiag_stratonovich.jl
@@ -86,14 +86,14 @@ end
     soloop = solve(proboop, EulerHeun(), dt = dtnd, save_noise = true)
 
     res_sde_u0, res_sde_p = adjoint_sensitivities(soloop, EulerHeun(), t = Array(t),
-                                                  dg_discrete = dg!,
+                                                  dgdu_discrete = dg!,
                                                   dt = dtnd, adaptive = false,
                                                   sensealg = BacksolveAdjoint())
 
     @info res_sde_p
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtnd, adaptive = false,
                                                     sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()))
 
@@ -103,7 +103,7 @@ end
     @info res_sde_pa
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtnd, adaptive = false,
                                                     sensealg = BacksolveAdjoint(autojacvec = false))
 
@@ -113,7 +113,7 @@ end
     @info res_sde_pa
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtnd, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()))
 
@@ -123,7 +123,7 @@ end
     @info res_sde_pa
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtnd, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()))
 
@@ -133,7 +133,7 @@ end
     @info res_sde_pa
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtnd, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(autojacvec = false))
 
@@ -144,7 +144,7 @@ end
 
     @test_broken res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol, EulerHeun(),
                                                                  t = Array(t),
-                                                                 dg_discrete = dg!,
+                                                                 dgdu_discrete = dg!,
                                                                  dt = dtnd,
                                                                  adaptive = false,
                                                                  sensealg = BacksolveAdjoint())
@@ -155,7 +155,7 @@ end
     @info res_sde_pa
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtnd, adaptive = false,
                                                     sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()))
 
@@ -165,7 +165,7 @@ end
     @info res_sde_pa
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtnd, adaptive = false,
                                                     sensealg = BacksolveAdjoint(autojacvec = false))
 
@@ -176,7 +176,7 @@ end
 
     @test_broken res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol, EulerHeun(),
                                                                  t = Array(t),
-                                                                 dg_discrete = dg!,
+                                                                 dgdu_discrete = dg!,
                                                                  dt = dtnd,
                                                                  adaptive = false,
                                                                  sensealg = InterpolatingAdjoint())
@@ -187,7 +187,7 @@ end
     @info res_sde_pa
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtnd, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()))
 
@@ -197,7 +197,7 @@ end
     @info res_sde_pa
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtnd, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(autojacvec = false))
 
@@ -280,14 +280,14 @@ end
     #oop
 
     res_sde_u0, res_sde_p = adjoint_sensitivities(soloop, EulerHeun(), t = tarray,
-                                                  dg_discrete = dg!,
+                                                  dgdu_discrete = dg!,
                                                   dt = dtmix, adaptive = false,
                                                   sensealg = BacksolveAdjoint(noisemixing = true))
 
     @info res_sde_p
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtmix, adaptive = false,
                                                     sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP(),
                                                                                 noisemixing = true))
@@ -298,7 +298,7 @@ end
     @info res_sde_pa
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtmix, adaptive = false,
                                                     sensealg = BacksolveAdjoint(autojacvec = false,
                                                                                 noisemixing = true))
@@ -309,7 +309,7 @@ end
     @info res_sde_pa
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtmix, adaptive = false,
                                                     sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP(),
                                                                                 noisemixing = true))
@@ -320,7 +320,7 @@ end
     @info res_sde_pa
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop, EulerHeun(), t = tarray,
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtmix, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(noisemixing = true))
 
@@ -330,7 +330,7 @@ end
     @info res_sde_pa
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop, EulerHeun(), t = tarray,
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtmix, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(noisemixing = true,
                                                                                     autojacvec = ZygoteVJP()))
@@ -341,7 +341,7 @@ end
     @info res_sde_pa
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop, EulerHeun(), t = tarray,
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtmix, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(autojacvec = false,
                                                                                     noisemixing = true))
@@ -352,13 +352,13 @@ end
     @info res_sde_pa
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtmix, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP(),
                                                                                     noisemixing = true))
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop, EulerHeun(), t = tarray,
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtmix, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP(),
                                                                                     noisemixing = true))
@@ -370,7 +370,7 @@ end
 
     @test_broken res_sde_u0, res_sde_p = adjoint_sensitivities(sol, EulerHeun(),
                                                                t = Array(t),
-                                                               dg_discrete = dg!,
+                                                               dgdu_discrete = dg!,
                                                                dt = dtmix, adaptive = false,
                                                                sensealg = BacksolveAdjoint(noisemixing = true))
 
@@ -380,7 +380,7 @@ end
     @info res_sde_p
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtmix, adaptive = false,
                                                     sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP(),
                                                                                 noisemixing = true))
@@ -391,7 +391,7 @@ end
     @info res_sde_pa
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtmix, adaptive = false,
                                                     sensealg = BacksolveAdjoint(autojacvec = false,
                                                                                 noisemixing = true))
@@ -402,7 +402,7 @@ end
     @info res_sde_pa
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtmix, adaptive = false,
                                                     sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP(),
                                                                                 noisemixing = true))
@@ -414,7 +414,7 @@ end
 
     @test_broken res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol, EulerHeun(),
                                                                  t = Array(t),
-                                                                 dg_discrete = dg!,
+                                                                 dgdu_discrete = dg!,
                                                                  dt = dtmix,
                                                                  adaptive = false,
                                                                  sensealg = InterpolatingAdjoint(noisemixing = true))
@@ -425,7 +425,7 @@ end
     @info res_sde_pa
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtmix, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(noisemixing = true,
                                                                                     autojacvec = ZygoteVJP()))
@@ -436,7 +436,7 @@ end
     @info res_sde_pa
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol, EulerHeun(), t = tarray,
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtmix, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(autojacvec = false,
                                                                                     noisemixing = true))
@@ -447,7 +447,7 @@ end
     @info res_sde_pa
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtmix, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP(),
                                                                                     noisemixing = true))
@@ -529,13 +529,13 @@ end
     # BacksolveAdjoint
 
     res_sde_u0, res_sde_p = adjoint_sensitivities(soloop, EulerHeun(), t = tarray,
-                                                  dg_discrete = dg!,
+                                                  dgdu_discrete = dg!,
                                                   dt = dtmix, adaptive = false,
                                                   sensealg = BacksolveAdjoint(noisemixing = true))
 
     @test_broken res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(),
                                                                  t = tarray,
-                                                                 dg_discrete = dg!,
+                                                                 dgdu_discrete = dg!,
                                                                  dt = dtmix,
                                                                  adaptive = false,
                                                                  sensealg = BacksolveAdjoint(noisemixing = true))
@@ -574,13 +574,13 @@ end
     # InterpolatingAdjoint
 
     res_sde_u0, res_sde_p = adjoint_sensitivities(soloop, EulerHeun(), t = tarray,
-                                                  dg_discrete = dg!,
+                                                  dgdu_discrete = dg!,
                                                   dt = dtmix, adaptive = false,
                                                   sensealg = InterpolatingAdjoint(noisemixing = true))
 
     @test_broken res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(),
                                                                  t = tarray,
-                                                                 dg_discrete = dg!,
+                                                                 dgdu_discrete = dg!,
                                                                  dt = dtmix,
                                                                  adaptive = false,
                                                                  sensealg = InterpolatingAdjoint(noisemixing = true))

--- a/test/sde_scalar_ito.jl
+++ b/test/sde_scalar_ito.jl
@@ -82,14 +82,14 @@ solve with continuous adjoint sensitivity tools
 """
 
 # for Ito sense
-gs_u0, gs_p = adjoint_sensitivities(solIto, EM(), t = Array(t), dg_discrete = dg!,
+gs_u0, gs_p = adjoint_sensitivities(solIto, EM(), t = Array(t), dgdu_discrete = dg!,
                                     dt = dt, adaptive = false,
                                     sensealg = BacksolveAdjoint(),
                                     corfunc_analytical = corfunc)
 
 @info gs_u0, gs_p
 
-gs_u0a, gs_pa = adjoint_sensitivities(solIto, EM(), t = Array(t), dg_discrete = dg!,
+gs_u0a, gs_pa = adjoint_sensitivities(solIto, EM(), t = Array(t), dgdu_discrete = dg!,
                                       dt = dt, adaptive = false,
                                       sensealg = BacksolveAdjoint(autojacvec = SciMLSensitivity.ReverseDiffVJP()))
 
@@ -100,7 +100,7 @@ gs_u0a, gs_pa = adjoint_sensitivities(solIto, EM(), t = Array(t), dg_discrete = 
 
 # for Strat sense
 res_u0, res_p = adjoint_sensitivities(solStrat, EulerHeun(), t = Array(t),
-                                      dg_discrete = dg!,
+                                      dgdu_discrete = dg!,
                                       dt = dt, adaptive = false,
                                       sensealg = BacksolveAdjoint())
 

--- a/test/sde_scalar_stratonovich.jl
+++ b/test/sde_scalar_stratonovich.jl
@@ -49,14 +49,14 @@ p2 = [1.01, 0.87]
     @test isapprox(sol.u_analytic, sol.u, atol = 1e-4)
 
     res_sde_u0, res_sde_p = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                  dg_discrete = dg!,
+                                                  dgdu_discrete = dg!,
                                                   dt = dtscalar, adaptive = false,
                                                   sensealg = BacksolveAdjoint())
 
     @show res_sde_u0, res_sde_p
 
     res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtscalar, adaptive = false,
                                                     sensealg = BacksolveAdjoint(autojacvec = false))
 
@@ -64,7 +64,7 @@ p2 = [1.01, 0.87]
     @test isapprox(res_sde_p, res_sde_p2, atol = 1e-8)
 
     res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtscalar, adaptive = false,
                                                     sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()))
 
@@ -74,7 +74,7 @@ p2 = [1.01, 0.87]
     @show res_sde_u02, res_sde_p2
 
     res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = tend / 1e2, adaptive = false,
                                                     sensealg = InterpolatingAdjoint())
 
@@ -84,7 +84,7 @@ p2 = [1.01, 0.87]
     @show res_sde_u02, res_sde_p2
 
     res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtscalar, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(autojacvec = false))
 
@@ -94,7 +94,7 @@ p2 = [1.01, 0.87]
     @show res_sde_u02, res_sde_p2
 
     res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtscalar, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()))
 
@@ -152,14 +152,14 @@ end
     @test isapprox(sol.u_analytic, sol.u, atol = 1e-4)
 
     res_sde_u0, res_sde_p = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                  dg_discrete = dg!,
+                                                  dgdu_discrete = dg!,
                                                   dt = dtscalar, adaptive = false,
                                                   sensealg = BacksolveAdjoint())
 
     @show res_sde_u0, res_sde_p
 
     res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtscalar, adaptive = false,
                                                     sensealg = BacksolveAdjoint(autojacvec = false))
 
@@ -167,7 +167,7 @@ end
     @test isapprox(res_sde_p, res_sde_p2, atol = 1e-8)
 
     res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtscalar, adaptive = false,
                                                     sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()))
 
@@ -177,7 +177,7 @@ end
     @show res_sde_u02, res_sde_p2
 
     res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = tend / 1e2, adaptive = false,
                                                     sensealg = InterpolatingAdjoint())
 
@@ -187,7 +187,7 @@ end
     @show res_sde_u02, res_sde_p2
 
     res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtscalar, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(autojacvec = false))
 
@@ -197,7 +197,7 @@ end
     @show res_sde_u02, res_sde_p2
 
     res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol, EulerHeun(), t = Array(t),
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dtscalar, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()))
 

--- a/test/sde_stratonovich.jl
+++ b/test/sde_stratonovich.jl
@@ -41,7 +41,7 @@ p2 = [1.01, 0.87]
     prob_oop_ode = ODEProblem(f_oop_linear, u₀, (tstart, tend), p)
     sol_oop_ode = solve(prob_oop_ode, Tsit5(), saveat = t, abstol = abstol, reltol = reltol)
     res_ode_u0, res_ode_p = adjoint_sensitivities(sol_oop_ode, Tsit5(), t = t,
-                                                  dg_discrete = dg!, abstol = abstol,
+                                                  dgdu_discrete = dg!, abstol = abstol,
                                                   reltol = reltol,
                                                   sensealg = BacksolveAdjoint())
 
@@ -66,13 +66,13 @@ p2 = [1.01, 0.87]
     sol_oop_sde = solve(prob_oop_sde, EulerHeun(), dt = 1e-4, adaptive = false,
                         save_noise = true)
     res_sde_u0, res_sde_p = adjoint_sensitivities(sol_oop_sde,
-                                                  EulerHeun(), t = t, dg_discrete = dg!,
+                                                  EulerHeun(), t = t, dgdu_discrete = dg!,
                                                   dt = 1e-2, sensealg = BacksolveAdjoint())
 
     @info res_sde_p
 
     res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol_oop_sde,
-                                                    EulerHeun(), t = t, dg_discrete = dg!,
+                                                    EulerHeun(), t = t, dgdu_discrete = dg!,
                                                     dt = 1e-2,
                                                     sensealg = InterpolatingAdjoint())
 
@@ -113,7 +113,7 @@ end
                          adaptive = false, save_noise = true)
 
     res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dt1, adaptive = false,
                                                     sensealg = BacksolveAdjoint())
 
@@ -121,7 +121,7 @@ end
 
     # test consitency for different switches for the noise Jacobian
     res_sde_u02a, res_sde_p2a = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
-                                                      dg_discrete = dg!,
+                                                      dgdu_discrete = dg!,
                                                       dt = dt1, adaptive = false,
                                                       sensealg = BacksolveAdjoint(autojacvec = false))
 
@@ -131,7 +131,7 @@ end
     @info res_sde_p2a
 
     res_sde_u02a, res_sde_p2a = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
-                                                      dg_discrete = dg!,
+                                                      dgdu_discrete = dg!,
                                                       dt = dt1, adaptive = false,
                                                       sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()))
 
@@ -141,7 +141,7 @@ end
     @info res_sde_p2a
 
     res_sde_u02a, res_sde_p2a = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
-                                                      dg_discrete = dg!,
+                                                      dgdu_discrete = dg!,
                                                       dt = tend / dt1, adaptive = false,
                                                       sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()))
 
@@ -182,7 +182,7 @@ end
     @info "InterpolatingAdjoint SDE"
 
     res_sde_u02a, res_sde_p2a = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
-                                                      dg_discrete = dg!,
+                                                      dgdu_discrete = dg!,
                                                       dt = dt1, adaptive = false,
                                                       sensealg = InterpolatingAdjoint())
 
@@ -192,7 +192,7 @@ end
     @info res_sde_p2a
 
     res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dt1, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(autojacvec = false))
 
@@ -200,7 +200,7 @@ end
     @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1e-6)
 
     res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dt1, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()))
 
@@ -208,7 +208,7 @@ end
     @test isapprox(res_sde_p2, res_sde_p2a, rtol = 1e-6)
 
     res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dt1, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()))
 
@@ -240,12 +240,12 @@ end
     @info "Diagonal Adjoint"
 
     res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dt1, adaptive = false,
                                                     sensealg = BacksolveAdjoint())
 
     res_sde_u02a, res_sde_p2a = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
-                                                      dg_discrete = dg!,
+                                                      dgdu_discrete = dg!,
                                                       dt = dt1, adaptive = false,
                                                       sensealg = InterpolatingAdjoint())
 
@@ -253,7 +253,7 @@ end
     @test isapprox(res_sde_u02, res_sde_u02a, rtol = 2e-5)
 
     res_sde_u02a, res_sde_p2a = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
-                                                      dg_discrete = dg!,
+                                                      dgdu_discrete = dg!,
                                                       dt = dt1, adaptive = false,
                                                       sensealg = InterpolatingAdjoint(autojacvec = false))
 
@@ -261,7 +261,7 @@ end
     @test isapprox(res_sde_u02, res_sde_u02a, rtol = 2e-5)
 
     res_sde_u02a, res_sde_p2a = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
-                                                      dg_discrete = dg!,
+                                                      dgdu_discrete = dg!,
                                                       dt = dt1, adaptive = false,
                                                       sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()))
 
@@ -269,7 +269,7 @@ end
     @test isapprox(res_sde_u02, res_sde_u02a, rtol = 2e-5)
 
     res_sde_u02a, res_sde_p2a = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
-                                                      dg_discrete = dg!,
+                                                      dgdu_discrete = dg!,
                                                       dt = dt1, adaptive = false,
                                                       sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()))
 
@@ -277,7 +277,7 @@ end
     @test isapprox(res_sde_u02, res_sde_u02a, rtol = 2e-5)
 
     res_sde_u02a, res_sde_p2a = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
-                                                      dg_discrete = dg!,
+                                                      dgdu_discrete = dg!,
                                                       dt = dt1, adaptive = false,
                                                       sensealg = BacksolveAdjoint(autojacvec = false))
 
@@ -285,7 +285,7 @@ end
     @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1e-7)
 
     res_sde_u02a, res_sde_p2a = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
-                                                      dg_discrete = dg!,
+                                                      dgdu_discrete = dg!,
                                                       dt = dt1, adaptive = false,
                                                       sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()))
 
@@ -293,7 +293,7 @@ end
     @test isapprox(res_sde_u02, res_sde_u02a, rtol = 1e-7)
 
     res_sde_u02a, res_sde_p2a = adjoint_sensitivities(sol_oop_sde2, EulerHeun(), t = tarray,
-                                                      dg_discrete = dg!,
+                                                      dgdu_discrete = dg!,
                                                       dt = dt1, adaptive = false,
                                                       sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()))
 
@@ -353,7 +353,7 @@ end
     res_sde_forward = ForwardDiff.gradient(GSDE, p2)
 
     res_sde_u0, res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
-                                                  dg_discrete = dg!,
+                                                  dgdu_discrete = dg!,
                                                   dt = dt1, adaptive = false,
                                                   sensealg = BacksolveAdjoint())
 
@@ -362,7 +362,7 @@ end
     @info res_sde_p
 
     res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dt1, adaptive = false,
                                                     sensealg = BacksolveAdjoint(autojacvec = false))
 
@@ -372,7 +372,7 @@ end
     @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-5)
 
     res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dt1, adaptive = false,
                                                     sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()))
 
@@ -382,7 +382,7 @@ end
     @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-5)
 
     res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dt1, adaptive = false,
                                                     sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()))
 
@@ -392,7 +392,7 @@ end
     @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-10)
 
     res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dt1, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()))
 
@@ -400,7 +400,7 @@ end
     @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-4)
 
     res_sde_u0, res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
-                                                  dg_discrete = dg!,
+                                                  dgdu_discrete = dg!,
                                                   dt = dt1, adaptive = false,
                                                   sensealg = InterpolatingAdjoint())
 
@@ -408,7 +408,7 @@ end
     @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-7)
 
     res_sde_u0, res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
-                                                  dg_discrete = dg!,
+                                                  dgdu_discrete = dg!,
                                                   dt = dt1, adaptive = false,
                                                   sensealg = InterpolatingAdjoint(autojacvec = false))
 
@@ -416,7 +416,7 @@ end
     @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-7)
 
     res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
-                                                    dg_discrete = dg!,
+                                                    dgdu_discrete = dg!,
                                                     dt = dt1, adaptive = false,
                                                     sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()))
 
@@ -433,7 +433,7 @@ end
     sol_oop_sde = solve(prob_oop_sde, EulerHeun(), dt = dt1, adaptive = false,
                         save_noise = true)
     res_oop_u0, res_oop_p = adjoint_sensitivities(sol_oop_sde, EulerHeun(), t = tarray,
-                                                  dg_discrete = dg!,
+                                                  dgdu_discrete = dg!,
                                                   dt = dt1, adaptive = false,
                                                   sensealg = BacksolveAdjoint())
 
@@ -444,7 +444,7 @@ end
     sol_sde = solve(prob_sde, EulerHeun(), dt = dt1, adaptive = false, save_noise = true)
 
     res_sde_u0, res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
-                                                  dg_discrete = dg!,
+                                                  dgdu_discrete = dg!,
                                                   dt = dt1, adaptive = false,
                                                   sensealg = BacksolveAdjoint())
 
@@ -454,7 +454,7 @@ end
     @info res_sde_p
 
     res_sde_u0, res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
-                                                  dg_discrete = dg!,
+                                                  dgdu_discrete = dg!,
                                                   dt = dt1, adaptive = false,
                                                   sensealg = BacksolveAdjoint(autojacvec = false))
 
@@ -464,7 +464,7 @@ end
     @info res_sde_p
 
     res_sde_u0, res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
-                                                  dg_discrete = dg!,
+                                                  dgdu_discrete = dg!,
                                                   dt = dt1, adaptive = false,
                                                   sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()))
 
@@ -474,7 +474,7 @@ end
     @info res_sde_p
 
     res_sde_u0, res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
-                                                  dg_discrete = dg!,
+                                                  dgdu_discrete = dg!,
                                                   dt = dt1, adaptive = false,
                                                   sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()))
 
@@ -484,7 +484,7 @@ end
     @info res_sde_p
 
     res_sde_u0, res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
-                                                  dg_discrete = dg!,
+                                                  dgdu_discrete = dg!,
                                                   dt = dt1, adaptive = false,
                                                   sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP()))
 
@@ -492,7 +492,7 @@ end
     @test isapprox(res_sde_u0, res_oop_u0, rtol = 1e-4)
 
     res_sde_u0, res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
-                                                  dg_discrete = dg!,
+                                                  dgdu_discrete = dg!,
                                                   dt = dt1, adaptive = false,
                                                   sensealg = InterpolatingAdjoint())
 
@@ -500,7 +500,7 @@ end
     @test isapprox(res_sde_u0, res_oop_u0, rtol = 1e-4)
 
     res_sde_u0, res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
-                                                  dg_discrete = dg!,
+                                                  dgdu_discrete = dg!,
                                                   dt = dt1, adaptive = false,
                                                   sensealg = InterpolatingAdjoint(autojacvec = false))
 
@@ -508,7 +508,7 @@ end
     @test isapprox(res_sde_u0, res_oop_u0, rtol = 1e-4)
 
     res_sde_u0, res_sde_p = adjoint_sensitivities(sol_sde, EulerHeun(), t = tarray,
-                                                  dg_discrete = dg!,
+                                                  dgdu_discrete = dg!,
                                                   dt = dt1, adaptive = false,
                                                   sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()))
 

--- a/test/shadowing.jl
+++ b/test/shadowing.jl
@@ -592,7 +592,8 @@ end
 
         lss_problem = ForwardLSSProblem(sol_attractor,
                                         ForwardLSS(LSSregularizer = SciMLSensitivity.TimeDilation(10.0),
-                                                   g = g), dgdu_discrete = dgu,
+                                                   g = g), t = sol_attractor.t,
+                                        dgdu_discrete = dgu,
                                         dgdp_discrete = dgp)
         resfw = shadow_forward(lss_problem)
 

--- a/test/shadowing.jl
+++ b/test/shadowing.jl
@@ -606,13 +606,12 @@ end
 
         @test resfw≈res rtol=1e-1
 
-        nilsas_prob = NILSASProblem(sol_attractor, NILSAS(nseg, nstep, M, g = g),
-                                    t = sol_attractor.t, dgdu_discrete = dgu,
-                                    dgdp_discrete = dgp)
-        res = shadow_adjoint(nilsas_prob, Tsit5())
-
-        @info res
-
-        @test resfw≈res rtol=1e-1
+        @test_throws ErrorException nilsas_prob=NILSASProblem(sol_attractor,
+                                                              NILSAS(nseg, nstep, M, g = g),
+                                                              t = sol_attractor.t,
+                                                              dgdu_discrete = dgu,
+                                                              dgdp_discrete = dgp)
+        # res = shadow_adjoint(nilsas_prob, Tsit5())
+        # @test resfw ≈ res rtol = 1e-1
     end
 end

--- a/test/shadowing.jl
+++ b/test/shadowing.jl
@@ -25,7 +25,7 @@ using Zygote
         sol_attractor = solve(prob_attractor, Vern9(), abstol = 1e-14, reltol = 1e-14)
 
         g(u, p, t) = u[end]
-        function dg(out, u, p, t, i=nothing)
+        function dg(out, u, p, t, i = nothing)
             fill!(out, zero(eltype(u)))
             out[end] = one(eltype(u))
         end
@@ -168,11 +168,11 @@ using Zygote
         sol_attractor = solve(prob_attractor, Vern9(), abstol = 1e-14, reltol = 1e-14)
 
         g(u, p, t) = u[end] + sum(p)
-        function dgu(out, u, p, t, i=nothing)
+        function dgu(out, u, p, t, i = nothing)
             fill!(out, zero(eltype(u)))
             out[end] = one(eltype(u))
         end
-        function dgp(out, u, p, t, i=nothing)
+        function dgp(out, u, p, t, i = nothing)
             fill!(out, one(eltype(p)))
         end
 
@@ -247,11 +247,11 @@ using Zygote
                               saveat = 0.01)
 
         g(u, p, t) = u[end]^2 / 2 + sum(p)
-        function dgu(out, u, p, t, i=nothing)
+        function dgu(out, u, p, t, i = nothing)
             fill!(out, zero(eltype(u)))
             out[end] = u[end]
         end
-        function dgp(out, u, p, t, i=nothing)
+        function dgp(out, u, p, t, i = nothing)
             fill!(out, one(eltype(p)))
         end
 
@@ -370,7 +370,7 @@ end
         prob_attractor = ODEProblem(lorenz!, sol_init[end], tspan_attractor, p)
 
         g(u, p, t) = u[end]
-        function dg(out, u, p, t, i=nothing)
+        function dg(out, u, p, t, i = nothing)
             fill!(out, zero(eltype(u)))
             out[end] = one(eltype(u))
         end

--- a/test/steady_state.jl
+++ b/test/steady_state.jl
@@ -31,8 +31,12 @@ Random.seed!(12345)
         nothing
     end
 
-    function dg!(out, u, p, t, i)
+    function dgdu!(out, u, p, t, i)
         (out .= -2.0 .+ u)
+    end
+
+    function dgdp!(out, u, p, t, i)
+        (out .= p)
     end
 
     function g(u, p, t)
@@ -55,7 +59,7 @@ Random.seed!(12345)
         delg_delp = copy(p)
 
         jac!(J, sol_analytical, p, nothing)
-        dg!(vec(gx), sol_analytical, p, nothing, nothing)
+        dgdu!(vec(gx), sol_analytical, p, nothing, nothing)
         paramjac!(fp, sol_analytical, p, nothing)
 
         lambda = J' \ gx'
@@ -95,28 +99,29 @@ Random.seed!(12345)
                      reltol = 1e-14, abstol = 1e-14)
 
         res1a = adjoint_sensitivities(sol1, DynamicSS(Rodas5()),
-                                      sensealg = SteadyStateAdjoint(), g, dg!)
+                                      sensealg = SteadyStateAdjoint(), dgdu = dgdu!,
+                                      dgdp = dgdp!, g = g)
         res1b = adjoint_sensitivities(sol1, DynamicSS(Rodas5()),
-                                      sensealg = SteadyStateAdjoint(), g, nothing)
+                                      sensealg = SteadyStateAdjoint(), g = g)
         res1c = adjoint_sensitivities(sol1, DynamicSS(Rodas5()),
-                                      sensealg = SteadyStateAdjoint(autodiff = false), g,
-                                      nothing)
+                                      sensealg = SteadyStateAdjoint(autodiff = false),
+                                      g = g)
         res1d = adjoint_sensitivities(sol1, DynamicSS(Rodas5()),
                                       sensealg = SteadyStateAdjoint(autojacvec = TrackerVJP()),
-                                      g, nothing)
+                                      g = g)
         res1e = adjoint_sensitivities(sol1, DynamicSS(Rodas5()),
                                       sensealg = SteadyStateAdjoint(autojacvec = ReverseDiffVJP()),
-                                      g, nothing)
+                                      g = g)
         res1f = adjoint_sensitivities(sol1, DynamicSS(Rodas5()),
                                       sensealg = SteadyStateAdjoint(autojacvec = ZygoteVJP()),
-                                      g, nothing)
+                                      g = g)
         res1g = adjoint_sensitivities(sol1, DynamicSS(Rodas5()),
                                       sensealg = SteadyStateAdjoint(autodiff = false,
-                                                                    autojacvec = false), g,
-                                      nothing)
+                                                                    autojacvec = false),
+                                      g = g)
         res1h = adjoint_sensitivities(sol1, DynamicSS(Rodas5()),
                                       sensealg = SteadyStateAdjoint(autojacvec = EnzymeVJP()),
-                                      g, nothing)
+                                      g = g)
 
         # with jac, without param_jac
         f2 = ODEFunction(f!; jac = jac!)
@@ -124,28 +129,29 @@ Random.seed!(12345)
         sol2 = solve(prob2, DynamicSS(Rodas5(), reltol = 1e-14, abstol = 1e-14),
                      reltol = 1e-14, abstol = 1e-14)
         res2a = adjoint_sensitivities(sol2, DynamicSS(Rodas5()),
-                                      sensealg = SteadyStateAdjoint(), g, dg!)
+                                      sensealg = SteadyStateAdjoint(), dgdu = dgdu!,
+                                      dgdp = dgdp!, g = g)
         res2b = adjoint_sensitivities(sol2, DynamicSS(Rodas5()),
-                                      sensealg = SteadyStateAdjoint(), g, nothing)
+                                      sensealg = SteadyStateAdjoint(), g = g)
         res2c = adjoint_sensitivities(sol2, DynamicSS(Rodas5()),
-                                      sensealg = SteadyStateAdjoint(autodiff = false), g,
-                                      nothing)
+                                      sensealg = SteadyStateAdjoint(autodiff = false),
+                                      g = g)
         res2d = adjoint_sensitivities(sol2, DynamicSS(Rodas5()),
                                       sensealg = SteadyStateAdjoint(autojacvec = TrackerVJP()),
-                                      g, nothing)
+                                      g = g)
         res2e = adjoint_sensitivities(sol2, DynamicSS(Rodas5()),
                                       sensealg = SteadyStateAdjoint(autojacvec = ReverseDiffVJP()),
-                                      g, nothing)
+                                      g = g)
         res2f = adjoint_sensitivities(sol2, DynamicSS(Rodas5()),
                                       sensealg = SteadyStateAdjoint(autojacvec = ZygoteVJP()),
-                                      g, nothing)
+                                      g = g)
         res2g = adjoint_sensitivities(sol2, DynamicSS(Rodas5()),
                                       sensealg = SteadyStateAdjoint(autodiff = false,
-                                                                    autojacvec = false), g,
-                                      nothing)
+                                                                    autojacvec = false),
+                                      g = g)
         res2h = adjoint_sensitivities(sol2, DynamicSS(Rodas5()),
                                       sensealg = SteadyStateAdjoint(autojacvec = EnzymeVJP()),
-                                      g, nothing)
+                                      g = g)
 
         # without jac, without param_jac
         f3 = ODEFunction(f!)
@@ -153,28 +159,29 @@ Random.seed!(12345)
         sol3 = solve(prob3, DynamicSS(Rodas5(), reltol = 1e-14, abstol = 1e-14),
                      reltol = 1e-14, abstol = 1e-14)
         res3a = adjoint_sensitivities(sol3, DynamicSS(Rodas5()),
-                                      sensealg = SteadyStateAdjoint(), g, dg!)
+                                      sensealg = SteadyStateAdjoint(), dgdu = dgdu!,
+                                      dgdp = dgdp!, g = g)
         res3b = adjoint_sensitivities(sol3, DynamicSS(Rodas5()),
-                                      sensealg = SteadyStateAdjoint(), g, nothing)
+                                      sensealg = SteadyStateAdjoint(), g = g)
         res3c = adjoint_sensitivities(sol3, DynamicSS(Rodas5()),
-                                      sensealg = SteadyStateAdjoint(autodiff = false), g,
-                                      nothing)
+                                      sensealg = SteadyStateAdjoint(autodiff = false),
+                                      g = g)
         res3d = adjoint_sensitivities(sol3, DynamicSS(Rodas5()),
                                       sensealg = SteadyStateAdjoint(autojacvec = TrackerVJP()),
-                                      g, nothing)
+                                      g = g)
         res3e = adjoint_sensitivities(sol3, DynamicSS(Rodas5()),
                                       sensealg = SteadyStateAdjoint(autojacvec = ReverseDiffVJP()),
-                                      g, nothing)
+                                      g = g)
         res3f = adjoint_sensitivities(sol3, DynamicSS(Rodas5()),
                                       sensealg = SteadyStateAdjoint(autojacvec = ZygoteVJP()),
-                                      g, nothing)
+                                      g = g)
         res3g = adjoint_sensitivities(sol3, DynamicSS(Rodas5()),
                                       sensealg = SteadyStateAdjoint(autodiff = false,
-                                                                    autojacvec = false), g,
-                                      nothing)
+                                                                    autojacvec = false),
+                                      g = g)
         res3h = adjoint_sensitivities(sol3, DynamicSS(Rodas5()),
                                       sensealg = SteadyStateAdjoint(autojacvec = EnzymeVJP()),
-                                      g, nothing)
+                                      g = g)
 
         @test norm(res_analytical' .- res1a) < 1e-7
         @test norm(res_analytical' .- res1b) < 1e-7
@@ -212,29 +219,30 @@ Random.seed!(12345)
                        reltol = 1e-14, abstol = 1e-14)
 
         res4a = adjoint_sensitivities(soloop, DynamicSS(Rodas5()),
-                                      sensealg = SteadyStateAdjoint(), g, dg!)
+                                      sensealg = SteadyStateAdjoint(), dgdu = dgdu!,
+                                      dgdp = dgdp!, g = g)
         res4b = adjoint_sensitivities(soloop, DynamicSS(Rodas5()),
-                                      sensealg = SteadyStateAdjoint(), g, nothing)
+                                      sensealg = SteadyStateAdjoint(), g = g)
         res4c = adjoint_sensitivities(soloop, DynamicSS(Rodas5()),
-                                      sensealg = SteadyStateAdjoint(autodiff = false), g,
-                                      nothing)
+                                      sensealg = SteadyStateAdjoint(autodiff = false),
+                                      g = g)
         res4d = adjoint_sensitivities(soloop, DynamicSS(Rodas5()),
                                       sensealg = SteadyStateAdjoint(autojacvec = TrackerVJP()),
-                                      g, nothing)
+                                      g = g)
         res4e = adjoint_sensitivities(soloop, DynamicSS(Rodas5()),
                                       sensealg = SteadyStateAdjoint(autojacvec = ReverseDiffVJP()),
-                                      g, nothing)
+                                      g = g)
         res4f = adjoint_sensitivities(soloop, DynamicSS(Rodas5()),
                                       sensealg = SteadyStateAdjoint(autojacvec = ZygoteVJP()),
-                                      g, nothing)
+                                      g = g)
         res4g = adjoint_sensitivities(soloop, DynamicSS(Rodas5()),
                                       sensealg = SteadyStateAdjoint(autodiff = false,
-                                                                    autojacvec = false), g,
-                                      nothing)
+                                                                    autojacvec = false),
+                                      g = g)
         res4h = adjoint_sensitivities(soloop, DynamicSS(Rodas5()),
                                       sensealg = SteadyStateAdjoint(autodiff = true,
-                                                                    autojacvec = false), g,
-                                      nothing)
+                                                                    autojacvec = false),
+                                      g = g)
 
         @test norm(res_analytical' .- res4a) < 1e-7
         @test norm(res_analytical' .- res4b) < 1e-7
@@ -286,9 +294,9 @@ using Zygote
 
         sol = solve(prob, DynamicSS(Rodas5()))
         res1 = adjoint_sensitivities(sol, DynamicSS(Rodas5()),
-                                     sensealg = SteadyStateAdjoint(), g1, nothing)
+                                     sensealg = SteadyStateAdjoint(), g = g1)
         res2 = adjoint_sensitivities(sol, DynamicSS(Rodas5()),
-                                     sensealg = SteadyStateAdjoint(), g2, nothing)
+                                     sensealg = SteadyStateAdjoint(), g = g2)
 
         dp1 = Zygote.gradient(p -> sum(solve(prob, DynamicSS(Rodas5()), u0 = u0, p = p,
                                              sensealg = SteadyStateAdjoint())), p)
@@ -338,9 +346,9 @@ using Zygote
 
         soloop = solve(proboop, DynamicSS(Rodas5()))
         res1oop = adjoint_sensitivities(soloop, DynamicSS(Rodas5()),
-                                        sensealg = SteadyStateAdjoint(), g1, nothing)
+                                        sensealg = SteadyStateAdjoint(), g = g1)
         res2oop = adjoint_sensitivities(soloop, DynamicSS(Rodas5()),
-                                        sensealg = SteadyStateAdjoint(), g2, nothing)
+                                        sensealg = SteadyStateAdjoint(), g = g2)
 
         dp1oop = Zygote.gradient(p -> sum(solve(proboop, DynamicSS(Rodas5()), u0 = u0,
                                                 p = p, sensealg = SteadyStateAdjoint())), p)


### PR DESCRIPTION
See: 
https://github.com/SciML/SciMLSensitivity.jl/issues/286
https://github.com/SciML/SciMLSensitivity.jl/issues/302

Continuous cost version: 
https://github.com/SciML/SciMLSensitivity.jl/pull/285 

Throws an error when a discrete cost is used but only a `g` is provided. 
Also computes `dgdp_continuous` via AD/FiniteDiff correctly now if only a `g` is provided.