### PR TITLE
Support the use of callbacks that exclusively exist in the reverse pass

### DIFF
--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -455,8 +455,12 @@ function generate_callbacks(sensefun, dgdu, dgdp, λ, t, t0, callback, init_cb,
         cur_time = Ref(length(t))
     end
 
-    reverse_cbs = setup_reverse_callbacks(callback, sensealg, dgdu, dgdp, cur_time,
-                                          terminated)
+    if callback !== nothing && callback.affect! isa TrackedAffect
+        reverse_cbs = setup_reverse_callbacks(callback, sensealg, dgdu, dgdp, cur_time,
+                                              terminated)
+    else
+        reverse_cbs = callback
+    end
     init_cb || return reverse_cbs, nothing
 
     # callbacks can lead to non-unique time points

--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -455,12 +455,9 @@ function generate_callbacks(sensefun, dgdu, dgdp, λ, t, t0, callback, init_cb,
         cur_time = Ref(length(t))
     end
 
-    if callback !== nothing && callback.affect! isa TrackedAffect
-        reverse_cbs = setup_reverse_callbacks(callback, sensealg, dgdu, dgdp, cur_time,
-                                              terminated)
-    else
-        reverse_cbs = callback
-    end
+    reverse_cbs = setup_reverse_callbacks(callback, sensealg, dgdu, dgdp, cur_time,
+                                          terminated)
+
     init_cb || return reverse_cbs, nothing
 
     # callbacks can lead to non-unique time points

--- a/test/callbacks/non_tracked_callbacks.jl
+++ b/test/callbacks/non_tracked_callbacks.jl
@@ -1,0 +1,37 @@
+using SciMLSensitivity, OrdinaryDiffEq, Zygote
+using DiffEqCallbacks
+using Test
+
+abstol = 1e-12
+reltol = 1e-12
+
+@testset "Non-tracked callbacks" begin
+    function f(du, u, p, t)
+        du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2] * t
+        du[2] = dy = -p[3] * u[2] + t * p[4] * u[1] * u[2]
+    end
+
+    p = [1.5, 1.0, 3.0, 1.0]
+    u0 = [1.0; 1.0]
+    prob = ODEProblem(f, u0, (0.0, 10.0), p)
+
+    sol = solve(prob, Tsit5(), abstol = abstol, reltol = reltol)
+
+    # Do a discrete adjoint problem
+    t = 0.0:0.5:10.0
+    # g(t,u,i) = (1-u)^2/2, L2 away from 1
+    function dg(out, u, p, t, i)
+        (out .= -2.0 .+ u)
+    end
+
+    saved_values = SavedValues(Float64, Vector{Float64})
+    cb = SavingCallback((u, t, integrator) -> copy(u[(end - 1):end]), saved_values)
+
+    _, res = adjoint_sensitivities(sol, Tsit5(), sensealg = BacksolveAdjoint(), t = t,
+                                   dgdu_discrete = dg, callback = cb)
+    _, res2 = adjoint_sensitivities(sol, Tsit5(), sensealg = BacksolveAdjoint(), t = t,
+                                    dgdu_discrete = dg)
+
+    @test res≈res2 rtol=1e-10
+    @test sol(saved_values.t).u≈saved_values.saveval rtol=1e-10
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,6 +88,7 @@ end
         @time @safetestset "Discrete Callbacks with ForwardDiffSensitivity" begin include("callbacks/forward_sensitivity_callback.jl") end
         @time @safetestset "Discrete Callbacks with Adjoints" begin include("callbacks/discrete_callbacks.jl") end
         @time @safetestset "SDE Callbacks" begin include("callbacks/SDE_callbacks.jl") end
+        @time @safetestset "Non-tracked callbacks" begin include("non_tracked_callbacks") end
     end
 
     if GROUP == "Callbacks2"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,7 +88,7 @@ end
         @time @safetestset "Discrete Callbacks with ForwardDiffSensitivity" begin include("callbacks/forward_sensitivity_callback.jl") end
         @time @safetestset "Discrete Callbacks with Adjoints" begin include("callbacks/discrete_callbacks.jl") end
         @time @safetestset "SDE Callbacks" begin include("callbacks/SDE_callbacks.jl") end
-        @time @safetestset "Non-tracked callbacks" begin include("non_tracked_callbacks") end
+        @time @safetestset "Non-tracked callbacks" begin include("callbacks/non_tracked_callbacks.jl") end
     end
 
     if GROUP == "Callbacks2"


### PR DESCRIPTION
Fixes: https://github.com/SciML/SciMLSensitivity.jl/issues/682

The test case stores the reconstructed state from `BacksolveAdjoint` and compares it with the forward solution. 