### PR TITLE
Handle terminating callbacks

### DIFF
--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -296,34 +296,27 @@ function _adjoint_sensitivities(sol, sensealg::QuadratureAdjoint, alg; t = nothi
             end
 
             # correction for end interval.
-            if t[end] != sol.prob.tspan[2]
+            if t[end] != sol.prob.tspan[2] && sol.retcode !== :Terminated
                 res .+= quadgk(integrand, t[end], sol.prob.tspan[end],
                                atol = abstol, rtol = reltol)[1]
+            end
+
+            if sol.retcode === :Terminated
+                integrand = update_integrand_and_dgrad(res, sensealg, callback, integrand,
+                                                       adj_prob, sol, dgdu_discrete,
+                                                       dgdp_discrete, dλ, dgrad, t[end],
+                                                       cur_time)
             end
 
             for i in (length(t) - 1):-1:1
                 res .+= quadgk(integrand, t[i], t[i + 1],
                                atol = abstol, rtol = reltol)[1]
                 if t[i] == t[i + 1]
-                    for cb in callback.discrete_callbacks
-                        if t[i] ∈ cb.affect!.event_times
-                            integrand = update_integrand_and_dgrad(res, sensealg, cb,
-                                                                   integrand, adj_prob, sol,
-                                                                   dgdu_discrete,
-                                                                   dgdp_discrete, dλ, dgrad,
-                                                                   t[i], cur_time)
-                        end
-                    end
-                    for cb in callback.continuous_callbacks
-                        if t[i] ∈ cb.affect!.event_times ||
-                           t[i] ∈ cb.affect_neg!.event_times
-                            integrand = update_integrand_and_dgrad(res, sensealg, cb,
-                                                                   integrand, adj_prob, sol,
-                                                                   dgdu_discrete,
-                                                                   dgdp_discrete, dλ, dgrad,
-                                                                   t[i], cur_time)
-                        end
-                    end
+                    integrand = update_integrand_and_dgrad(res, sensealg, callback,
+                                                           integrand,
+                                                           adj_prob, sol, dgdu_discrete,
+                                                           dgdp_discrete, dλ, dgrad, t[i],
+                                                           cur_time)
                 end
                 if dgdp_discrete !== nothing
                     @unpack y = integrand
@@ -349,8 +342,33 @@ function update_p_integrand(integrand::AdjointSensitivityIntegrand, p)
                                 sensealg, dgdp_cache, dgdp)
 end
 
-function update_integrand_and_dgrad(res, sensealg::QuadratureAdjoint, cb, integrand,
-                                    adj_prob, sol, dgdu, dgdp, dλ, dgrad, t, cur_time)
+function update_integrand_and_dgrad(res, sensealg::QuadratureAdjoint, callbacks, integrand,
+                                    adj_prob, sol, dgdu_discrete, dgdp_discrete, dλ, dgrad,
+                                    ti, cur_time)
+    for cb in callbacks.discrete_callbacks
+        if ti ∈ cb.affect!.event_times
+            integrand = _update_integrand_and_dgrad(res, sensealg, cb,
+                                                    integrand, adj_prob, sol,
+                                                    dgdu_discrete,
+                                                    dgdp_discrete, dλ, dgrad,
+                                                    ti, cur_time)
+        end
+    end
+    for cb in callbacks.continuous_callbacks
+        if ti ∈ cb.affect!.event_times ||
+           ti ∈ cb.affect_neg!.event_times
+            integrand = _update_integrand_and_dgrad(res, sensealg, cb,
+                                                    integrand, adj_prob, sol,
+                                                    dgdu_discrete,
+                                                    dgdp_discrete, dλ, dgrad,
+                                                    ti, cur_time)
+        end
+    end
+    return integrand
+end
+
+function _update_integrand_and_dgrad(res, sensealg::QuadratureAdjoint, cb, integrand,
+                                     adj_prob, sol, dgdu, dgdp, dλ, dgrad, t, cur_time)
     indx, pos_neg = get_indx(cb, t)
     tprev = get_tprev(cb, indx, pos_neg)
 

--- a/src/sensitivity_interface.jl
+++ b/src/sensitivity_interface.jl
@@ -93,7 +93,7 @@ and obtaining the sensitivities through the integral:
 As defined, that cost function only has non-zero values over nontrivial intervals. However, in many
 cases one may want to include in the cost function loss values at discrete points, for example, matching
 the data at time points `t`. In this case, terms of `g` can be represented by Dirac delta functions
-which are then applied in the corresponding ``\lambda^\star`` and ``\frac{dG}{dp}`` equations. 
+which are then applied in the corresponding ``\lambda^\star`` and ``\frac{dG}{dp}`` equations.
 
 For more information, see [Sensitivity Math Details](@ref sensitivity_math).
 
@@ -141,7 +141,7 @@ Only used if the `sol.prob isa SDEProblem`. If not given, this is
 - `callback`: callback functions to be used in the adjoint solve. Defaults to
   `nothing`.
 - `sensealg`: the choice for what adjoint method to use for the reverse solve.
-  Defaults to `InterpolatingAdjoint()`. See the 
+  Defaults to `InterpolatingAdjoint()`. See the
   [sensitivity algorithms](@ref sensitivity_diffeq) page for more details.
 - `kwargs`: any extra keyword arguments passed to the adjoint solve.
 
@@ -156,7 +156,7 @@ du0,dp = adjoint_sensitivities(sol,alg;t=ts,dgdu_discrete=dg,
                                checkpoints=sol.t,kwargs...)
 ```
 
-where `alg` is the ODE algorithm to solve the adjoint problem, `dgdu_discrete` is the 
+where `alg` is the ODE algorithm to solve the adjoint problem, `dgdu_discrete` is the
 jump function, `sensealg` is the sensitivity algorithm, and `ts` are the time points
 for data. `dg` is given by:
 


### PR DESCRIPTION
Some fixes for sensitivity methods and callbacks with `terminate!`
- `ForwardDiffSensitivity`: when a callback is terminating we don't want to save any `ts` (except the end point and start point). Otherwise, one will run into bounds errors if the callback is triggered later than the original time point (without duals). 
- `InterpolatingAdjoint`:  `tspan` had to be updated in the same manner as for `BacksolveAdjoint` (to avoid starting from `Inf`)
- `QuadratureAdjoint` : Apply callback correction and fix endpoint handling. 