### PR TITLE
Allow computation of sensitivity with respect to initial conditions for `NullParameters`

### DIFF
--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -232,7 +232,8 @@ function adjointdiffcache(g::G, sensealg, discrete, sol, dgdu::DG1, dgdp::DG2, f
         paramjac_config = nothing
         pf = nothing
     else
-        if DiffEqBase.isinplace(prob)
+        if DiffEqBase.isinplace(prob) &&
+           !(p === nothing || p === DiffEqBase.NullParameters())
             if !(prob isa RODEProblem)
                 pf = DiffEqBase.ParamJacobianWrapper(f, tspan[1], y)
             else

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -249,7 +249,7 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::Bool, dgrad, dy,
         end
         mul!(dλ', λ', J)
     end
-    if dgrad !== nothing
+    if dgrad !== nothing && !isempty(dgrad)
         @unpack pJ, pf, paramjac_config = S.diffcache
         if W === nothing
             if DiffEqBase.has_paramjac(f)
@@ -538,7 +538,7 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::ZygoteVJP, dgrad, 
             if tmp2 === nothing && !sensealg.autojacvec.allow_nothing
                 throw(ZygoteVJPNothingError())
             else
-                (dgrad[:] .= vec(tmp2))
+                !isempty(dgrad) && (dgrad[:] .= vec(tmp2))
             end
         end
     else
@@ -566,7 +566,7 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::ZygoteVJP, dgrad, 
             if tmp2 === nothing && !sensealg.autojacvec.allow_nothing
                 throw(ZygoteVJPNothingError())
             elseif tmp2 !== nothing
-                (dgrad[:] .= vec(tmp2))
+                !isempty(dgrad) && (dgrad[:] .= vec(tmp2))
             end
         end
     end
@@ -618,7 +618,8 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::EnzymeVJP, dgrad, 
         end
 
         dλ .= tmp1
-        dgrad !== nothing && (dgrad[:] .= vec(tmp2))
+        dgrad !== nothing && !(typeof(tmp2) <: DiffEqBase.NullParameters) &&
+            (dgrad[:] .= vec(tmp2))
         dy !== nothing && (dy .= tmp3)
     else
         if W === nothing

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -268,7 +268,7 @@ function _adjoint_sensitivities(sol, sensealg::QuadratureAdjoint, alg; t = nothi
 
     p = sol.prob.p
     if p === nothing || p === DiffEqBase.NullParameters()
-        return -adj_sol[end], nothing
+        return adj_sol[end], nothing
     else
         integrand = AdjointSensitivityIntegrand(sol, adj_sol, sensealg, dgdp_continuous)
 

--- a/test/null_parameters.jl
+++ b/test/null_parameters.jl
@@ -106,3 +106,137 @@ end
 @test Zygote.gradient(loss8, zeros(123))[1] == zeros(123)
 @test Zygote.gradient(loss9, zeros(123))[1] == zeros(123)
 @test_throws SciMLSensitivity.ZygoteVJPNothingError Zygote.gradient(loss10, zeros(123))[1]==zeros(123)
+
+## OOP tests for initial condition
+function loss_oop(u0; sensealg = nothing)
+    _prob = ODEProblem(dynamics, u0, (0.0, 1.0))
+    _sol = solve(_prob, Tsit5(), u0 = u0, sensealg = sensealg, abstol = 1e-12,
+                 reltol = 1e-12)
+    sum(abs2, Array(_sol)[:, end])
+end
+
+u0 = ones(2)
+Fdu0 = ForwardDiff.gradient(u0 -> loss_oop(u0), u0)
+
+# BacksolveAdjoint
+du0 = Zygote.gradient(u0 -> loss_oop(u0,
+                                     sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))),
+                      u0)[1]
+@test_throws SciMLSensitivity.ZygoteVJPNothingError Zygote.gradient(u0 -> loss_oop(u0,
+                                                                                   sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())),
+                                                                    u0)[1]
+@test Fdu0≈du0 rtol=1e-10
+du0 = Zygote.gradient(u0 -> loss_oop(u0,
+                                     sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP())),
+                      u0)[1]
+@test Fdu0≈du0 rtol=1e-10
+du0 = Zygote.gradient(u0 -> loss_oop(u0, sensealg = BacksolveAdjoint(autojacvec = false)),
+                      u0)[1]
+@test Fdu0≈du0 rtol=1e-10
+
+# InterpolatingAdjoint
+du0 = Zygote.gradient(u0 -> loss_oop(u0,
+                                     sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))),
+                      u0)[1]
+@test_throws SciMLSensitivity.ZygoteVJPNothingError Zygote.gradient(u0 -> loss_oop(u0,
+                                                                                   sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())),
+                                                                    u0)[1]
+@test Fdu0≈du0 rtol=1e-10
+du0 = Zygote.gradient(u0 -> loss_oop(u0,
+                                     sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP())),
+                      u0)[1]
+@test Fdu0≈du0 rtol=1e-10
+du0 = Zygote.gradient(u0 -> loss_oop(u0,
+                                     sensealg = InterpolatingAdjoint(autojacvec = false)),
+                      u0)[1]
+@test Fdu0≈du0 rtol=1e-10
+
+# QuadratureAdjoint
+du0 = Zygote.gradient(u0 -> loss_oop(u0,
+                                     sensealg = QuadratureAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))),
+                      u0)[1]
+@test_throws SciMLSensitivity.ZygoteVJPNothingError Zygote.gradient(u0 -> loss_oop(u0,
+                                                                                   sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())),
+                                                                    u0)[1]
+@test Fdu0≈du0 rtol=1e-10
+du0 = Zygote.gradient(u0 -> loss_oop(u0,
+                                     sensealg = QuadratureAdjoint(autojacvec = ReverseDiffVJP())),
+                      u0)[1]
+@test Fdu0≈du0 rtol=1e-10
+du0 = Zygote.gradient(u0 -> loss_oop(u0, sensealg = QuadratureAdjoint(autojacvec = false)),
+                      u0)[1]
+@test Fdu0≈du0 rtol=1e-10
+
+## iip tests for initial condition
+dynamics! = (dx, x, _p, _t) -> dx .= x
+
+function loss_iip(u0; sensealg = nothing)
+    _prob = ODEProblem(dynamics!, u0, (0.0, 1.0))
+    _sol = solve(_prob, Tsit5(), u0 = u0, sensealg = sensealg, abstol = 1e-12,
+                 reltol = 1e-12)
+    sum(abs2, Array(_sol)[:, end])
+end
+
+u0 = ones(2)
+Fdu0 = ForwardDiff.gradient(u0 -> loss_iip(u0), u0)
+
+# BacksolveAdjoint
+du0 = Zygote.gradient(u0 -> loss_iip(u0,
+                                     sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))),
+                      u0)[1]
+@test_throws SciMLSensitivity.ZygoteVJPNothingError Zygote.gradient(u0 -> loss_iip(u0,
+                                                                                   sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())),
+                                                                    u0)[1]
+@test Fdu0≈du0 rtol=1e-10
+du0 = Zygote.gradient(u0 -> loss_iip(u0,
+                                     sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP())),
+                      u0)[1]
+@test Fdu0≈du0 rtol=1e-10
+du0 = Zygote.gradient(u0 -> loss_iip(u0, sensealg = BacksolveAdjoint(autojacvec = false)),
+                      u0)[1]
+@test Fdu0≈du0 rtol=1e-10
+du0 = Zygote.gradient(u0 -> loss_iip(u0,
+                                     sensealg = BacksolveAdjoint(autojacvec = EnzymeVJP())),
+                      u0)[1]
+@test Fdu0≈du0 rtol=1e-10
+
+# InterpolatingAdjoint
+du0 = Zygote.gradient(u0 -> loss_iip(u0,
+                                     sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))),
+                      u0)[1]
+@test_throws SciMLSensitivity.ZygoteVJPNothingError Zygote.gradient(u0 -> loss_iip(u0,
+                                                                                   sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())),
+                                                                    u0)[1]
+@test Fdu0≈du0 rtol=1e-10
+du0 = Zygote.gradient(u0 -> loss_iip(u0,
+                                     sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP())),
+                      u0)[1]
+@test Fdu0≈du0 rtol=1e-10
+du0 = Zygote.gradient(u0 -> loss_iip(u0,
+                                     sensealg = InterpolatingAdjoint(autojacvec = false)),
+                      u0)[1]
+@test Fdu0≈du0 rtol=1e-10
+du0 = Zygote.gradient(u0 -> loss_iip(u0,
+                                     sensealg = InterpolatingAdjoint(autojacvec = EnzymeVJP())),
+                      u0)[1]
+@test Fdu0≈du0 rtol=1e-10
+
+# QuadratureAdjoint
+du0 = Zygote.gradient(u0 -> loss_iip(u0,
+                                     sensealg = QuadratureAdjoint(autojacvec = ZygoteVJP(allow_nothing = true))),
+                      u0)[1]
+@test_throws SciMLSensitivity.ZygoteVJPNothingError Zygote.gradient(u0 -> loss_iip(u0,
+                                                                                   sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP())),
+                                                                    u0)[1]
+@test Fdu0≈du0 rtol=1e-10
+du0 = Zygote.gradient(u0 -> loss_iip(u0,
+                                     sensealg = QuadratureAdjoint(autojacvec = ReverseDiffVJP())),
+                      u0)[1]
+@test Fdu0≈du0 rtol=1e-10
+du0 = Zygote.gradient(u0 -> loss_iip(u0, sensealg = QuadratureAdjoint(autojacvec = false)),
+                      u0)[1]
+@test Fdu0≈du0 rtol=1e-10
+du0 = Zygote.gradient(u0 -> loss_iip(u0,
+                                     sensealg = QuadratureAdjoint(autojacvec = EnzymeVJP())),
+                      u0)[1]
+@test Fdu0≈du0 rtol=1e-10

--- a/test/null_parameters.jl
+++ b/test/null_parameters.jl
@@ -1,5 +1,6 @@
 import OrdinaryDiffEq: ODEProblem, solve, Tsit5
 import Zygote
+import ForwardDiff
 using SciMLSensitivity, Test
 
 dynamics = (x, _p, _t) -> x

--- a/test/null_parameters.jl
+++ b/test/null_parameters.jl
@@ -167,6 +167,14 @@ du0 = Zygote.gradient(u0 -> loss_oop(u0, sensealg = QuadratureAdjoint(autojacvec
                       u0)[1]
 @test Fdu0≈du0 rtol=1e-10
 
+# ForwardDiffSensitivity
+du0 = Zygote.gradient(u0 -> loss_oop(u0, sensealg = ForwardDiffSensitivity()), u0)[1]
+@test Fdu0≈du0 rtol=1e-6
+du0 = Zygote.gradient(u0 -> loss_oop(u0, sensealg = ForwardDiffSensitivity()), u0)[1]
+@test Fdu0≈du0 rtol=1e-6
+du0 = Zygote.gradient(u0 -> loss_oop(u0, sensealg = ForwardDiffSensitivity()), u0)[1]
+@test Fdu0≈du0 rtol=1e-6
+
 ## iip tests for initial condition
 dynamics! = (dx, x, _p, _t) -> dx .= x
 
@@ -240,3 +248,11 @@ du0 = Zygote.gradient(u0 -> loss_iip(u0,
                                      sensealg = QuadratureAdjoint(autojacvec = EnzymeVJP())),
                       u0)[1]
 @test Fdu0≈du0 rtol=1e-10
+
+# ForwardDiffSensitivity
+du0 = Zygote.gradient(u0 -> loss_iip(u0, sensealg = ForwardDiffSensitivity()), u0)[1]
+@test Fdu0≈du0 rtol=1e-6
+du0 = Zygote.gradient(u0 -> loss_iip(u0, sensealg = ForwardDiffSensitivity()), u0)[1]
+@test Fdu0≈du0 rtol=1e-6
+du0 = Zygote.gradient(u0 -> loss_iip(u0, sensealg = ForwardDiffSensitivity()), u0)[1]
+@test Fdu0≈du0 rtol=1e-6


### PR DESCRIPTION
Fixes sign in `QuadratureAdjoint` + `dgrad` computations for `p === nothing || p === DiffEqBase.NullParameters()`.