### PR TITLE
handle diffusion functions that do not depend on the parameters

### DIFF
--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -792,7 +792,7 @@ function _jacNoise!(λ, y, p, t, S::TS, isnoise::ReverseDiffVJP, dgrad, dλ,
 
         deriv = ReverseDiff.deriv(tp)
         if dgrad !== nothing
-            if tmp2 !== nothing
+            if deriv !== nothing
                 !isempty(dgrad) && (dgrad[:, i] .= vec(deriv))
             end
         end

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -709,7 +709,7 @@ function _jacNoise!(λ, y, p, t, S::TS, isnoise::Bool, dgrad, dλ,
             for i in 1:m
                 tmp = λ' * pJ[((i - 1) * m + 1):(i * m), :]
                 if dgrad !== nothing
-                    if tmp2 !== nothing
+                    if tmp !== nothing
                         !isempty(dgrad) && (dgrad[:, i] .= vec(tmp))
                     end
                 end

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -708,7 +708,11 @@ function _jacNoise!(λ, y, p, t, S::TS, isnoise::Bool, dgrad, dλ,
             m = size(prob.noise_rate_prototype)[2]
             for i in 1:m
                 tmp = λ' * pJ[((i - 1) * m + 1):(i * m), :]
-                dgrad[:, i] .= vec(tmp)
+                if dgrad !== nothing
+                    if tmp2 !== nothing
+                        !isempty(dgrad) && (dgrad[:, i] .= vec(tmp))
+                    end
+                end
             end
         end
     end
@@ -787,7 +791,11 @@ function _jacNoise!(λ, y, p, t, S::TS, isnoise::ReverseDiffVJP, dgrad, dλ,
         ReverseDiff.reverse_pass!(tapei)
 
         deriv = ReverseDiff.deriv(tp)
-        dgrad[:, i] .= vec(deriv)
+        if dgrad !== nothing
+            if tmp2 !== nothing
+                !isempty(dgrad) && (dgrad[:, i] .= vec(deriv))
+            end
+        end
         ReverseDiff.pull_value!(output)
 
         if StochasticDiffEq.is_diagonal_noise(prob)
@@ -815,7 +823,11 @@ function _jacNoise!(λ, y, p, t, S::TS, isnoise::ZygoteVJP, dgrad, dλ,
                     copy(out_[i])
                 end
                 tmp1, tmp2 = back(λi) #issue: tmp2 = zeros(p)
-                dgrad[:, i] .= vec(tmp2)
+                if dgrad !== nothing
+                    if tmp2 !== nothing
+                        !isempty(dgrad) && (dgrad[:, i] .= vec(tmp2))
+                    end
+                end
                 dλ !== nothing && (dλ[:, i] .= vec(tmp1))
                 dy !== nothing && (dy[i] = _dy)
             end
@@ -825,7 +837,11 @@ function _jacNoise!(λ, y, p, t, S::TS, isnoise::ZygoteVJP, dgrad, dλ,
                     f(u, p, t)[i]
                 end
                 tmp1, tmp2 = back(λi)
-                dgrad[:, i] .= vec(tmp2)
+                if dgrad !== nothing
+                    if tmp2 !== nothing
+                        !isempty(dgrad) && (dgrad[:, i] .= vec(tmp2))
+                    end
+                end
                 dλ !== nothing && (dλ[:, i] .= vec(tmp1))
                 dy !== nothing && (dy[i] = _dy)
             end
@@ -839,7 +855,11 @@ function _jacNoise!(λ, y, p, t, S::TS, isnoise::ZygoteVJP, dgrad, dλ,
                     copy(out_[:, i])
                 end
                 tmp1, tmp2 = back(λ)#issue with Zygote.Buffer
-                dgrad[:, i] .= vec(tmp2)
+                if dgrad !== nothing
+                    if tmp2 !== nothing
+                        !isempty(dgrad) && (dgrad[:, i] .= vec(tmp2))
+                    end
+                end
                 dλ !== nothing && (dλ[:, i] .= vec(tmp1))
                 dy !== nothing && (dy[:, i] .= vec(_dy))
             end
@@ -849,7 +869,11 @@ function _jacNoise!(λ, y, p, t, S::TS, isnoise::ZygoteVJP, dgrad, dλ,
                     f(u, p, t)[:, i]
                 end
                 tmp1, tmp2 = back(λ)
-                dgrad[:, i] .= vec(tmp2)
+                if dgrad !== nothing
+                    if tmp2 !== nothing
+                        !isempty(dgrad) && (dgrad[:, i] .= vec(tmp2))
+                    end
+                end
                 if tmp1 === nothing
                     # if a column of the noise matrix is zero, Zygote returns nothing.
                     dλ !== nothing && (dλ[:, i] .= false)

--- a/src/nilsas.jl
+++ b/src/nilsas.jl
@@ -53,7 +53,7 @@ struct NILSASProblem{A, NILSS, Aprob, Qcache, solType, z0Type, tType, G, T, DG1,
     dgdp_discrete::DG2
 end
 
-function NILSASProblem(sol, sensealg::NILSAS;
+function NILSASProblem(sol, sensealg::NILSAS, alg;
                        t = nothing, dgdu_discrete = nothing, dgdp_discrete = nothing,
                        dgdu_continuous = nothing, dgdp_continuous = nothing, g = sensealg.g,
                        kwargs...)
@@ -101,7 +101,8 @@ function NILSASProblem(sol, sensealg::NILSAS;
     tspan = (tspan[2] - T_seg, tspan[2])
     checkpoints = tspan[1]:dtsave:tspan[2]
 
-    adjoint_prob = ODEAdjointProblem(sol, adjoint_sensealg, t, dgdu_discrete, dgdp_discrete,
+    adjoint_prob = ODEAdjointProblem(sol, adjoint_sensealg, alg, t, dgdu_discrete,
+                                     dgdp_discrete,
                                      dgdu_continuous, dgdp_continuous,
                                      g;
                                      checkpoints = checkpoints,
@@ -293,7 +294,8 @@ function adjoint_sense(prob::NILSASProblem, nilsas::NILSAS, alg; kwargs...)
         t1 = tspan[1] - (nseg - iseg + 1) * T_seg
         t2 = tspan[1] - (nseg - iseg) * T_seg
         checkpoints = t1:dtsave:t2
-        _prob = ODEAdjointProblem(sol, adjoint_sensealg, t, dgdu_discrete, dgdp_discrete,
+        _prob = ODEAdjointProblem(sol, adjoint_sensealg, alg, t, dgdu_discrete,
+                                  dgdp_discrete,
                                   dgdu, dgdp, g;
                                   checkpoints = checkpoints, z0 = z0, M = M, nilss = nilss,
                                   tspan = (t1, t2), kwargs...)

--- a/test/shadowing.jl
+++ b/test/shadowing.jl
@@ -538,14 +538,14 @@ end
 
         @info resfw
 
-        nilsas_prob = NILSASProblem(sol_attractor, NILSAS(nseg, nstep, M, g = g))
+        nilsas_prob = NILSASProblem(sol_attractor, NILSAS(nseg, nstep, M, g = g), Tsit5())
         res = shadow_adjoint(nilsas_prob, Tsit5())
 
         @info res
 
         @test resfw≈res atol=1e-1
 
-        nilsas_prob = NILSASProblem(sol_attractor, NILSAS(nseg, nstep, M, g = g),
+        nilsas_prob = NILSASProblem(sol_attractor, NILSAS(nseg, nstep, M, g = g), Tsit5(),
                                     dgdu_continuous = dg)
         res = shadow_adjoint(nilsas_prob, Tsit5())
 
@@ -599,7 +599,7 @@ end
 
         @info resfw
 
-        nilsas_prob = NILSASProblem(sol_attractor, NILSAS(nseg, nstep, M, g = g))
+        nilsas_prob = NILSASProblem(sol_attractor, NILSAS(nseg, nstep, M, g = g), Tsit5())
         res = shadow_adjoint(nilsas_prob, Tsit5())
 
         @info res
@@ -608,6 +608,7 @@ end
 
         @test_throws ErrorException nilsas_prob=NILSASProblem(sol_attractor,
                                                               NILSAS(nseg, nstep, M, g = g),
+                                                              Tsit5(),
                                                               t = sol_attractor.t,
                                                               dgdu_discrete = dgu,
                                                               dgdp_discrete = dgp)


### PR DESCRIPTION
Fixes the `MethodError: no method matching vec(::Nothing)` in #697. 