### PR TITLE
fix tag error for fallback case, fixes #718

### DIFF
--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -253,7 +253,9 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::Bool, dgrad, dy,
 
                     # This is really slow and allocates, but it's a fallback only for a
                     # rare case so it can be optimized in the future
-                    jacobian!(J, _uf, y, nothing, sensealg, nothing)
+                    _f_cache = DiffEqBase.isinplace(prob) ? deepcopy(y) : nothing
+                    _jac_config = build_jac_config(sensealg, _uf, t * dλ)
+                    jacobian!(J, _uf, y, _f_cache, sensealg, _jac_config)
                 else
                     uf.t = t
                     uf.p = p

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -253,8 +253,7 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::Bool, dgrad, dy,
 
                     # This is really slow and allocates, but it's a fallback only for a
                     # rare case so it can be optimized in the future
-                    _jac_config = build_jac_config(sensealg, uf, t * dλ)
-                    jacobian!(J, _uf, y, f_cache, sensealg, _jac_config)
+                    jacobian!(J, _uf, y, nothing, sensealg, nothing)
                 else
                     uf.t = t
                     uf.p = p


### PR DESCRIPTION
This fix lets ForwardDiff manage its own cache for this fallback case.  Since the cache is only used once anyway, I don't think performance will be adversely affected compared to the previous code.