### PR TITLE
Fix for non-diagonal, non-square SDEs

### DIFF
--- a/src/backsolve_adjoint.jl
+++ b/src/backsolve_adjoint.jl
@@ -101,9 +101,11 @@ function split_states(du, u, t, S::ODEBacksolveSensitivityFunction; update = tru
 
     elseif typeof(du) <: AbstractMatrix
         # non-diagonal noise
-        dλ = @view du[1:idx, 1:idx]
-        dgrad = @view du[(idx + 1):(end - idx), 1:idx]
-        dy = @view du[(end - idx + 1):end, 1:idx]
+        m = prob.noise_rate_prototype === nothing ? idx :
+            size(prob.noise_rate_prototype)[2]
+        dλ = @view du[1:idx, 1:m]
+        dgrad = @view du[(idx + 1):(end - idx), 1:m]
+        dy = @view du[(end - idx + 1):end, 1:m]
     end
     λ, grad, _y, dλ, dgrad, dy
 end

--- a/src/backsolve_adjoint.jl
+++ b/src/backsolve_adjoint.jl
@@ -331,7 +331,9 @@ end
         # scalar noise case
         noise_matrix = nothing
     else
-        noise_matrix = similar(z0, length(z0), numstates)
+        m = sol.prob.noise_rate_prototype === nothing ? numstates :
+            size(sol.prob.noise_rate_prototype)[2]
+        noise_matrix = similar(z0, length(z0), m)
         noise_matrix .= false
     end
 

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -827,7 +827,7 @@ function _jacNoise!(λ, y, p, t, S::TS, isnoise::ReverseDiffVJP, dgrad, dλ,
 
     # number of Wiener processes
     noise_rate_prototype = prob.noise_rate_prototype
-    m = noise_rate_prototype === nothing ? numindvar : size(noise_rate_prototype)[2]
+    m = noise_rate_prototype === nothing ? length(y) : size(noise_rate_prototype)[2]
 
     for i in 1:m
         tapei = S.diffcache.paramjac_noise_config[i]
@@ -874,7 +874,7 @@ function _jacNoise!(λ, y, p, t, S::TS, isnoise::ZygoteVJP, dgrad, dλ,
 
     # number of Wiener processes
     noise_rate_prototype = prob.noise_rate_prototype
-    m = noise_rate_prototype === nothing ? numindvar : size(noise_rate_prototype)[2]
+    m = noise_rate_prototype === nothing ? length(y) : size(noise_rate_prototype)[2]
 
     if StochasticDiffEq.is_diagonal_noise(prob)
         if inplace_sensitivity(S)

--- a/src/interpolating_adjoint.jl
+++ b/src/interpolating_adjoint.jl
@@ -248,8 +248,10 @@ function split_states(du, u, t, S::TS;
 
     elseif typeof(du) <: AbstractMatrix
         # non-diagonal noise and noise mixing case
-        dλ = @view du[1:idx, 1:idx]
-        dgrad = @view du[(idx + 1):end, 1:idx]
+        m = prob.noise_rate_prototype === nothing ? idx :
+            size(prob.noise_rate_prototype)[2]
+        dλ = @view du[1:idx, 1:m]
+        dgrad = @view du[(idx + 1):end, 1:m]
     end
 
     λ, grad, y, dλ, dgrad, nothing

--- a/src/interpolating_adjoint.jl
+++ b/src/interpolating_adjoint.jl
@@ -492,7 +492,9 @@ end
         # scalar noise case
         noise_matrix = nothing
     else
-        noise_matrix = similar(z0, length(z0), numstates)
+        m = sol.prob.noise_rate_prototype === nothing ? numstates :
+            size(sol.prob.noise_rate_prototype)[2]
+        noise_matrix = similar(z0, length(z0), m)
         noise_matrix .= false
     end
 

--- a/src/sde_tools.jl
+++ b/src/sde_tools.jl
@@ -75,6 +75,6 @@ function (Tfunc::StochasticTransformedFunction)(u, p, t)
     end
     du = f(u, p, t)
 
-    du = @. du - ducor
+    ducor !== nothing && (du = @. du - ducor)
     return du
 end

--- a/test/sde_nondiag_stratonovich.jl
+++ b/test/sde_nondiag_stratonovich.jl
@@ -1,5 +1,6 @@
 using Test, LinearAlgebra
 using SciMLSensitivity, StochasticDiffEq
+using DiffEqNoiseProcess
 using FiniteDiff, ForwardDiff, Zygote
 using Random
 


### PR DESCRIPTION
The dimension of the Brownian process `m` remains the same in the adjoint. (Until now, the implementation assumed `d=m` so that index errors were thrown otherwise.)