### PR TITLE
Support `ReverseDiffVJP(true)` for hybrid DEs

### DIFF
--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -220,15 +220,15 @@ function jacobianmat!(JM::AbstractMatrix{<:Number}, f, x::AbstractArray{<:Number
 end
 function vecjacobian!(dλ, y, λ, p, t, S::TS;
                       dgrad = nothing, dy = nothing,
-                      W = nothing) where {TS <: SensitivityFunction}
-    _vecjacobian!(dλ, y, λ, p, t, S, S.sensealg.autojacvec, dgrad, dy, W)
+                      W = nothing, kwargs...) where {TS <: SensitivityFunction}
+    _vecjacobian!(dλ, y, λ, p, t, S, S.sensealg.autojacvec, dgrad, dy, W; kwargs...)
     return
 end
 
 function vecjacobian(y, λ, p, t, S::TS;
                      dgrad = nothing, dy = nothing,
-                     W = nothing) where {TS <: SensitivityFunction}
-    return _vecjacobian(y, λ, p, t, S, S.sensealg.autojacvec, dgrad, dy, W)
+                     W = nothing, kwargs...) where {TS <: SensitivityFunction}
+    return _vecjacobian(y, λ, p, t, S, S.sensealg.autojacvec, dgrad, dy, W; kwargs...)
 end
 
 function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::Bool, dgrad, dy,
@@ -418,7 +418,7 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::TrackerVJP, dgrad,
 end
 
 function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::ReverseDiffVJP, dgrad, dy,
-                       W) where {TS <: SensitivityFunction}
+                       W; recompile_tape = false) where {TS <: SensitivityFunction}
     @unpack sensealg = S
     prob = getprob(S)
     f = unwrapped_f(S.f)
@@ -431,7 +431,7 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::ReverseDiffVJP, dg
 
     if prob isa Union{SteadyStateProblem, NonlinearProblem} ||
        (eltype(λ) <: eltype(prob.u0) && typeof(t) <: eltype(prob.u0) &&
-        compile_tape(sensealg.autojacvec))
+        compile_tape(sensealg.autojacvec) && !recompile_tape)
         tape = S.diffcache.paramjac_config
 
         ## These other cases happen due to autodiff in stiff ODE solvers

--- a/test/callbacks/continuous_callbacks.jl
+++ b/test/callbacks/continuous_callbacks.jl
@@ -1,5 +1,5 @@
 using OrdinaryDiffEq, Zygote
-using SciMLSensitivity, Test, ForwardDiff
+using SciMLSensitivity, Test, ForwardDiff, FiniteDiff
 
 abstol = 1e-12
 reltol = 1e-12

--- a/test/callbacks/continuous_callbacks.jl
+++ b/test/callbacks/continuous_callbacks.jl
@@ -245,4 +245,37 @@ println("Continuous Callbacks")
         @test du01 ≈ dstuff[1:2]
         @test dp1 ≈ dstuff[3:4]
     end
+    @testset "Re-compile tape in ReverseDiffVJP" begin
+        N0 = [0.0] # initial population
+        p = [100.0, 50.0] # steady-state pop., M
+        tspan = (0.0, 10.0) # integration time
+
+        # system
+        f(D, u, p, t) = (D[1] = p[1] - u[1])
+
+        # when N = 3α/4 we inject M cells.
+        condition(u, t, integrator) = u[1] - 3 // 4 * integrator.p[1]
+        affect!(integrator) = integrator.u[1] += integrator.p[2]
+        cb = ContinuousCallback(condition, affect!, save_positions = (false, false))
+        prob = ODEProblem(f, N0, tspan, p)
+
+        function loss(p, cb, sensealg)
+            _prob = remake(prob, p = p)
+            _sol = solve(_prob, Tsit5(); callback = cb,
+                         abstol = 1e-14, reltol = 1e-14,
+                         sensealg = sensealg)
+            _sol[end][1]
+        end
+
+        gND = FiniteDiff.finite_difference_gradient(p -> loss(p, cb, nothing), p)
+        gFD = ForwardDiff.gradient(p -> loss(p, cb, nothing), p)
+        # @show gND # [0.9999546000702386, 0.00018159971904994378]
+        @test gND≈gFD rtol=1e-10
+
+        for compile_tape in (true, false)
+            sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP(compile_tape))
+            gZy = Zygote.gradient(p -> loss(p, cb, sensealg), p)[1]
+            @test gFD≈gZy rtol=1e-10
+        end
+    end
 end


### PR DESCRIPTION
This PR adds the kwarg `recompile_tape = true` to `vecjacobian!` to manually enforce a recompilation of the tape in the vjp computation of the event handling where a different/new tape must be generated. The original compiled tape can then still be used for the remaining vjps.