### PR TITLE
`solve_up` implementation for array of `ReverseDiff.TrackedReal`

### DIFF
--- a/src/reversediff.jl
+++ b/src/reversediff.jl
@@ -57,6 +57,7 @@ end
     abs(u)
 end
 
+# `ReverseDiff.TrackedArray`
 function DiffEqBase.solve_up(prob::DiffEqBase.DEProblem,
                              sensealg::Union{AbstractOverloadingSensitivityAlgorithm,
                                              Nothing}, u0::ReverseDiff.TrackedArray,
@@ -76,6 +77,28 @@ function DiffEqBase.solve_up(prob::DiffEqBase.DEProblem,
                                              Nothing}, u0::ReverseDiff.TrackedArray, p,
                              args...; kwargs...)
     ReverseDiff.track(DiffEqBase.solve_up, prob, sensealg, u0, p, args...; kwargs...)
+end
+
+# `AbstractArray{<:ReverseDiff.TrackedReal}`
+function DiffEqBase.solve_up(prob::DiffEqBase.DEProblem,
+                             sensealg::Union{AbstractOverloadingSensitivityAlgorithm,
+                                             Nothing}, u0::AbstractArray{<:ReverseDiff.TrackedReal},
+                             p::AbstractArray{<:ReverseDiff.TrackedReal}, args...; kwargs...)
+    DiffEqBase.solve_up(prob, sensealg, reduce(vcat, u0), reduce(vcat, p), args...; kwargs...)
+end
+
+function DiffEqBase.solve_up(prob::DiffEqBase.DEProblem,
+                             sensealg::Union{AbstractOverloadingSensitivityAlgorithm,
+                                             Nothing}, u0, p::AbstractArray{<:ReverseDiff.TrackedReal},
+                             args...; kwargs...)
+    DiffEqBase.solve_up(prob, sensealg, u0, reduce(vcat, p), args...; kwargs...)
+end
+
+function DiffEqBase.solve_up(prob::DiffEqBase.DEProblem,
+                             sensealg::Union{AbstractOverloadingSensitivityAlgorithm,
+                                             Nothing}, u0::AbstractArray{<:ReverseDiff.TrackedReal}, p,
+                             args...; kwargs...)
+    DiffEqBase.solve_up(prob, sensealg, reduce(vcat, u0), p, args...; kwargs...)
 end
 
 @inline function DiffEqNoiseProcess.wiener_randn(rng::Random.AbstractRNG,


### PR DESCRIPTION
Makes it possible to have initial state `u0`and/or parameters `p` be `AbstractArray{<:ReverseDiff.TrackedReal}`, which then calls the `ReverseDiff.TrackedArray` version.