### PR TITLE
Re-throw the VJP failure stack traces with a verbose option

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -16,8 +16,9 @@ function inplace_vjp(prob, u0, p, verbose)
         true
     catch e
         if verbose
-            @warn "EnzymeVJP tried and failed in the automated AD choice algorithm with the following error. (To turn off this printing, add `verbose = false` to the `solve` call)"
-            show(e)
+            @warn "EnzymeVJP tried and failed in the automated AD choice algorithm with the following error. (To turn off this printing, add `verbose = false` to the `solve` call)\n"
+            showerror(stderr,e)
+            println()
         end
         false
     end
@@ -47,8 +48,9 @@ function inplace_vjp(prob, u0, p, verbose)
         ReverseDiffVJP(compile)
     catch e
         if verbose
-            @warn "ReverseDiffVJP tried and failed in the automated AD choice algorithm with the following error. (To turn off this printing, add `verbose = false` to the `solve` call)"
-            show(e)
+            @warn "ReverseDiffVJP tried and failed in the automated AD choice algorithm with the following error. (To turn off this printing, add `verbose = false` to the `solve` call)\n"
+            showerror(stderr,e)
+            println()
         end
         false
     end
@@ -75,8 +77,9 @@ function automatic_sensealg_choice(prob::Union{SciMLBase.AbstractODEProblem,
             ZygoteVJP()
         catch e
             if verbose
-                @warn "ZygoteVJP tried and failed in the automated AD choice algorithm with the following error. (To turn off this printing, add `verbose = false` to the `solve` call)"
-                show(e)
+                @warn "ZygoteVJP tried and failed in the automated AD choice algorithm with the following error. (To turn off this printing, add `verbose = false` to the `solve` call)\n"
+                showerror(stderr,e)
+                println()
             end
             false
         end
@@ -87,8 +90,9 @@ function automatic_sensealg_choice(prob::Union{SciMLBase.AbstractODEProblem,
                 ReverseDiffVJP()
             catch e
                 if verbose
-                    @warn "ReverseDiffVJP tried and failed in the automated AD choice algorithm with the following error. (To turn off this printing, add `verbose = false` to the `solve` call)"
-                    show(e)
+                    @warn "ReverseDiffVJP tried and failed in the automated AD choice algorithm with the following error. (To turn off this printing, add `verbose = false` to the `solve` call)\n"
+                    showerror(stderr,e)
+                    println()
                 end
                 false
             end
@@ -100,8 +104,9 @@ function automatic_sensealg_choice(prob::Union{SciMLBase.AbstractODEProblem,
                 TrackerVJP()
             catch e
                 if verbose
-                    @warn "TrackerVJP tried and failed in the automated AD choice algorithm with the following error. (To turn off this printing, add `verbose = false` to the `solve` call)"
-                    show(e)
+                    @warn "TrackerVJP tried and failed in the automated AD choice algorithm with the following error. (To turn off this printing, add `verbose = false` to the `solve` call)\n"
+                    showerror(stderr,e)
+                    println()
                 end
                 false
             end

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -14,7 +14,11 @@ function inplace_vjp(prob, u0, p, verbose)
             nothing
         end
         true
-    catch
+    catch e
+        if verbose
+            @warn "EnzymeVJP tried and failed in the automated AD choice algorithm with the following error. (To turn off this printing, add `verbose = false` to the `solve` call)"
+            println(e)
+        end
         false
     end
     if ez
@@ -42,6 +46,10 @@ function inplace_vjp(prob, u0, p, verbose)
         end
         ReverseDiffVJP(compile)
     catch
+        if verbose
+            @warn "ReverseDiffVJP tried and failed in the automated AD choice algorithm with the following error. (To turn off this printing, add `verbose = false` to the `solve` call)"
+            println(e)
+        end
         false
     end
 
@@ -66,6 +74,10 @@ function automatic_sensealg_choice(prob::Union{SciMLBase.AbstractODEProblem,
             Zygote.gradient((u, p) -> sum(prob.f(u, p, prob.tspan[1])), u0, p)
             ZygoteVJP()
         catch
+            if verbose
+                @warn "ZygoteVJP tried and failed in the automated AD choice algorithm with the following error. (To turn off this printing, add `verbose = false` to the `solve` call)"
+                println(e)
+            end
             false
         end
 
@@ -74,6 +86,10 @@ function automatic_sensealg_choice(prob::Union{SciMLBase.AbstractODEProblem,
                 ReverseDiff.gradient((u, p) -> sum(prob.f(u, p, prob.tspan[1])), u0, p)
                 ReverseDiffVJP()
             catch
+                if verbose
+                    @warn "ReverseDiffVJP tried and failed in the automated AD choice algorithm with the following error. (To turn off this printing, add `verbose = false` to the `solve` call)"
+                    println(e)
+                end
                 false
             end
         end
@@ -83,6 +99,10 @@ function automatic_sensealg_choice(prob::Union{SciMLBase.AbstractODEProblem,
                 Tracker.gradient((u, p) -> sum(prob.f(u, p, prob.tspan[1])), u0, p)
                 TrackerVJP()
             catch
+                if verbose
+                    @warn "TrackerVJP tried and failed in the automated AD choice algorithm with the following error. (To turn off this printing, add `verbose = false` to the `solve` call)"
+                    println(e)
+                end
                 false
             end
         end

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -17,7 +17,7 @@ function inplace_vjp(prob, u0, p, verbose)
     catch e
         if verbose
             @warn "EnzymeVJP tried and failed in the automated AD choice algorithm with the following error. (To turn off this printing, add `verbose = false` to the `solve` call)"
-            println(e)
+            show(e)
         end
         false
     end
@@ -45,10 +45,10 @@ function inplace_vjp(prob, u0, p, verbose)
             return vec(du1)
         end
         ReverseDiffVJP(compile)
-    catch
+    catch e
         if verbose
             @warn "ReverseDiffVJP tried and failed in the automated AD choice algorithm with the following error. (To turn off this printing, add `verbose = false` to the `solve` call)"
-            println(e)
+            show(e)
         end
         false
     end
@@ -73,10 +73,10 @@ function automatic_sensealg_choice(prob::Union{SciMLBase.AbstractODEProblem,
         vjp = try
             Zygote.gradient((u, p) -> sum(prob.f(u, p, prob.tspan[1])), u0, p)
             ZygoteVJP()
-        catch
+        catch e
             if verbose
                 @warn "ZygoteVJP tried and failed in the automated AD choice algorithm with the following error. (To turn off this printing, add `verbose = false` to the `solve` call)"
-                println(e)
+                show(e)
             end
             false
         end
@@ -85,10 +85,10 @@ function automatic_sensealg_choice(prob::Union{SciMLBase.AbstractODEProblem,
             vjp = try
                 ReverseDiff.gradient((u, p) -> sum(prob.f(u, p, prob.tspan[1])), u0, p)
                 ReverseDiffVJP()
-            catch
+            catch e
                 if verbose
                     @warn "ReverseDiffVJP tried and failed in the automated AD choice algorithm with the following error. (To turn off this printing, add `verbose = false` to the `solve` call)"
-                    println(e)
+                    show(e)
                 end
                 false
             end
@@ -98,10 +98,10 @@ function automatic_sensealg_choice(prob::Union{SciMLBase.AbstractODEProblem,
             vjp = try
                 Tracker.gradient((u, p) -> sum(prob.f(u, p, prob.tspan[1])), u0, p)
                 TrackerVJP()
-            catch
+            catch e
                 if verbose
                     @warn "TrackerVJP tried and failed in the automated AD choice algorithm with the following error. (To turn off this printing, add `verbose = false` to the `solve` call)"
-                    println(e)
+                    show(e)
                 end
                 false
             end


### PR DESCRIPTION
On by default, since I think a lot of people would be better served to have clearer information as to why the auto-diffs are failing. An example of this is https://discourse.julialang.org/t/error-relating-to-zygote/95102/8.