### PR TITLE
Alternative: Fix for SciMLSensitivity.jl issue #564 and #809

### DIFF
--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -70,6 +70,33 @@ function TrackedAffect(t::Number, u, p, affect!, correction)
                   Vector{Int}(undef, 0))
 end
 
+function Base.hasproperty(f::TrackedAffect, s::Symbol)
+    if hasfield(TrackedAffect, s)               
+        return true
+    else
+        _affect = getfield(f, :affect!)
+        return hasfield(typeof(_affect), s)
+    end
+end
+
+function Base.getproperty(f::TrackedAffect, s::Symbol)
+    if hasfield(TrackedAffect, s)               
+        return getfield(f, s)
+    else
+        _affect = getfield(f, :affect!)
+        return getfield(_affect, s)
+    end
+end
+
+function Base.setproperty!(f::TrackedAffect, s::Symbol, value)
+    if hasfield(TrackedAffect, s)               
+        return setfield!(f, s, value)
+    else
+        _affect = getfield(f, :affect!)
+        return setfield!(_affect, s, value)
+    end
+end
+
 function (f::TrackedAffect)(integrator, event_idx = nothing)
     uleft = deepcopy(integrator.u)
     pleft = deepcopy(integrator.p)

--- a/test/callback_reversediff.jl
+++ b/test/callback_reversediff.jl
@@ -11,14 +11,21 @@ dosetimes = [1.0, 2.0, 4.0, 8.0]
 function affect!(integrator)
     integrator.u = integrator.u .+ 1
 end
-cb_ = PresetTimeCallback(dosetimes, affect!, save_positions = (false, false))
+
+function functionCalling(x, t, integrator)
+    # @info "Step: $(t)"
+end
+
+cbPreTime = PresetTimeCallback(dosetimes, affect!, save_positions = (false, false))
+cbFctCall = FunctionCallingCallback(functionCalling; func_everystep=true, func_start=true)
+
 function trueODEfunc(du, u, p, t)
     du .= -u
 end
 t = range(tspan[1], tspan[2], length = datasize)
 
 prob = ODEProblem(trueODEfunc, u0, tspan)
-ode_data = Array(solve(prob, Tsit5(), callback = cb_, saveat = t))
+ode_data = Array(solve(prob, Tsit5(), callback = CallbackSet(cbPreTime, cbFctCall), saveat = t))
 dudt2 = Chain(Dense(2, 50, tanh),
               Dense(50, 2))
 p, re = Flux.destructure(dudt2) # use this p as the initial condition!


### PR DESCRIPTION
Please see the discussion in [this PR](https://github.com/SciML/SciMLSensitivity.jl/pull/801) concerning [this issue](https://github.com/SciML/SciMLSensitivity.jl/issues/809) for further information.

This is an alternative approach to #801, that only requires this single, non-breaking PR (setproperty!, getproperty and hasproperty are overwritten for TrackedAffect to mimic inheritance).