### PR TITLE
Fix J and pJ construction for forward mode

### DIFF
--- a/docs/src/examples/sde/SDE_control.md
+++ b/docs/src/examples/sde/SDE_control.md
@@ -163,7 +163,8 @@ W1 = cumsum([zero(myparameters.dt); W[1:(end - 1)]], dims = 1)
 NG = CreateGrid(myparameters.ts, W1)
 
 # get control pulses
-p_all = ComponentArray(p_nn = p_nn, myparameters = [myparameters.Δ; myparameters.Ωmax; myparameters.κ])
+p_all = ComponentArray(p_nn = p_nn,
+                       myparameters = [myparameters.Δ; myparameters.Ωmax; myparameters.κ])
 # define SDE problem
 prob = SDEProblem{true}(qubit_drift!, qubit_diffusion!, vec(u0[:, 1]), myparameters.tspan,
                         p_all,
@@ -180,7 +181,9 @@ function g(u, p, t)
 end
 
 function loss(p_nn; alg = EM(), sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()))
-    pars = ComponentArray(p_nn = p_nn, myparameters = [myparameters.Δ; myparameters.Ωmax; myparameters.κ])
+    pars = ComponentArray(p_nn = p_nn,
+                          myparameters = [myparameters.Δ; myparameters.Ωmax;
+                                          myparameters.κ])
     u0 = prepare_initial(myparameters.dt, myparameters.numtraj)
 
     function prob_func(prob, i, repeat)
@@ -218,7 +221,9 @@ end
 # visualization -- run for new batch
 function visualize(p_nn; alg = EM())
     u0 = prepare_initial(myparameters.dt, myparameters.numtrajplot)
-    pars = ComponentArray(p_nn = p_nn, myparameters = [myparameters.Δ; myparameters.Ωmax; myparameters.κ])
+    pars = ComponentArray(p_nn = p_nn,
+                          myparameters = [myparameters.Δ; myparameters.Ωmax;
+                                          myparameters.κ])
 
     function prob_func(prob, i, repeat)
         # prepare initial state and applied control pulse
@@ -296,7 +301,8 @@ adtype = Optimization.AutoZygote()
 optf = Optimization.OptimizationFunction((x, p) -> loss(x), adtype)
 
 optprob = Optimization.OptimizationProblem(optf, p_nn)
-res = Optimization.solve(optprob, OptimizationOptimisers.Adam(myparameters.lr), callback = visualization_callback,
+res = Optimization.solve(optprob, OptimizationOptimisers.Adam(myparameters.lr),
+                         callback = visualization_callback,
                          maxiters = 100)
 
 # plot optimized control
@@ -498,7 +504,8 @@ W1 = cumsum([zero(myparameters.dt); W[1:(end - 1)]], dims = 1)
 NG = CreateGrid(myparameters.ts, W1)
 
 # get control pulses
-p_all = ComponentArray(p_nn = p_nn, myparameters = [myparameters.Δ; myparameters.Ωmax; myparameters.κ])
+p_all = ComponentArray(p_nn = p_nn,
+                       myparameters = [myparameters.Δ; myparameters.Ωmax; myparameters.κ])
 # define SDE problem
 prob = SDEProblem{true}(qubit_drift!, qubit_diffusion!, vec(u0[:, 1]), myparameters.tspan,
                         p_all,
@@ -528,7 +535,9 @@ function g(u, p, t)
 end
 
 function loss(p_nn; alg = EM(), sensealg = BacksolveAdjoint(autojacvec = ReverseDiffVJP()))
-    pars = ComponentArray(p_nn = p_nn, myparameters = [myparameters.Δ; myparameters.Ωmax; myparameters.κ])
+    pars = ComponentArray(p_nn = p_nn,
+                          myparameters = [myparameters.Δ; myparameters.Ωmax;
+                                          myparameters.κ])
     u0 = prepare_initial(myparameters.dt, myparameters.numtraj)
 
     function prob_func(prob, i, repeat)
@@ -572,7 +581,9 @@ a function of the time steps at which loss values are computed.
 ```@example sdecontrol
 function visualize(p_nn; alg = EM())
     u0 = prepare_initial(myparameters.dt, myparameters.numtrajplot)
-    pars = ComponentArray(p_nn = p_nn, myparameters = [myparameters.Δ; myparameters.Ωmax; myparameters.κ])
+    pars = ComponentArray(p_nn = p_nn,
+                          myparameters = [myparameters.Δ; myparameters.Ωmax;
+                                          myparameters.κ])
 
     function prob_func(prob, i, repeat)
         # prepare initial state and applied control pulse
@@ -653,7 +664,8 @@ adtype = Optimization.AutoZygote()
 optf = Optimization.OptimizationFunction((x, p) -> loss(x), adtype)
 
 optprob = Optimization.OptimizationProblem(optf, p_nn)
-res = Optimization.solve(optprob, OptimizationOptimisers.Adam(myparameters.lr), callback = visualization_callback,
+res = Optimization.solve(optprob, OptimizationOptimisers.Adam(myparameters.lr),
+                         callback = visualization_callback,
                          maxiters = 100)
 
 # plot optimized control

--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -101,7 +101,7 @@ function adjointdiffcache(g::G, sensealg, discrete, sol, dgdu::DG1, dgdp::DG2, f
         algevar_idxs = 1:0
     end
 
-    if !needs_jac && !(issemiexplicitdae || !isautojacvec)
+    if !needs_jac && !issemiexplicitdae && !(autojacvec isa Bool)
         J = nothing
     else
         if SciMLBase.forwarddiffs_model_time(alg)
@@ -142,7 +142,7 @@ function adjointdiffcache(g::G, sensealg, discrete, sol, dgdu::DG1, dgdp::DG2, f
         pg_config = nothing
     end
 
-    if DiffEqBase.has_jac(f) || (J === nothing)
+    if DiffEqBase.has_jac(f) || J === nothing
         jac_config = nothing
         uf = nothing
     else
@@ -198,7 +198,7 @@ function adjointdiffcache(g::G, sensealg, discrete, sol, dgdu::DG1, dgdp::DG2, f
     elseif autojacvec isa EnzymeVJP
         paramjac_config = get_paramjac_config(autojacvec, p, f, y, _p, _t; numindvar, alg)
         pf = get_pf(autojacvec; _f = unwrappedf, isinplace = isinplace, isRODE = isRODE)
-    elseif DiffEqBase.has_paramjac(f) || isautojacvec || quad ||
+    elseif DiffEqBase.has_paramjac(f) || quad || !(autojacvec isa Bool) ||
            autojacvec isa EnzymeVJP
         paramjac_config = nothing
         pf = nothing
@@ -221,7 +221,7 @@ function adjointdiffcache(g::G, sensealg, discrete, sol, dgdu::DG1, dgdp::DG2, f
         end
     end
 
-    pJ = (quad || isautojacvec) ? nothing : similar(u0, numindvar, numparams)
+    pJ = (quad || !(autojacvec isa Bool)) ? nothing : similar(u0, numindvar, numparams)
 
     f_cache = isinplace ? deepcopy(u0) : nothing
 


### PR DESCRIPTION
I can't seem to figure out a MWE for the problem. But a longer form trying to use the updated HNN in DiffEqFlux https://github.com/SciML/DiffEqFlux.jl/blob/a1b5846bc48f1f50b745dc7c2e5a5a5298abb96b/src/hnn.jl. The Jacobian and Parameter Jacobians were not being constructed despite both ForwardDiff and FiniteDiff needing them (FiniteDiff case was fine but this should fix the forwardDiff case)