### PR TITLE
Fix scalar indexing for diagonal-noise SDEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,3 @@ For information on using the package,
 [see the stable documentation](https://docs.sciml.ai/SciMLSensitivity/stable/). Use the
 [in-development documentation](https://docs.sciml.ai/SciMLSensitivity/dev/) for the version of
 the documentation, which contains the unreleased features.
-

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -918,7 +918,7 @@ function _jacNoise!(λ, y, p, t, S::TS, isnoise::ZygoteVJP, dgrad, dλ,
                     !isempty(dgrad) && (dgrad .= stack(tmp2))
                 end
             end
-            dλ !== nothing && (dλ .= vec(stack(first.(out))))
+            dλ !== nothing && (dλ .= stack(first.(out)))
             dy !== nothing && (dy .= _dy)
         end
     else

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -890,8 +890,9 @@ function _jacNoise!(λ, y, p, t, S::TS, isnoise::ZygoteVJP, dgrad, dλ,
         end
         out = [back(x) for x in eachcol(Diagonal(λ))]
         if dgrad !== nothing
-            if tmp2 !== nothing
-                !isempty(dgrad) && (dgrad .= vec(stack(last.(out))))
+            tmp2 = last.(out)
+            if !(eltype(tmp2) isa Nothing)
+                !isempty(dgrad) && (dgrad .= vec(stack(tmp2)))
             end
         end
         dλ !== nothing && (dλ .= vec(stack(first.(out))))


### PR DESCRIPTION
Fixes scalar indexing in https://github.com/SciML/SciMLSensitivity.jl/issues/854. 

Probably we should do something similar for ReverseDiff https://github.com/SciML/SciMLSensitivity.jl/blob/master/src/derivative_wrappers.jl#L832-L863?

We should also add a dispatch for Enzyme (https://github.com/SciML/SciMLSensitivity.jl/issues/627 here or in a follow-up PR).