### PR TITLE
Make has_original_jac check original_jac

### DIFF
--- a/src/forward_sensitivity.jl
+++ b/src/forward_sensitivity.jl
@@ -38,7 +38,7 @@ end
 
 TruncatedStacktraces.@truncate_stacktrace ODEForwardSensitivityFunction
 
-has_original_jac(S) = isdefined(S, :original_jac) && S.jac !== nothing
+has_original_jac(S) = isdefined(S, :original_jac) && S.original_jac !== nothing
 
 struct NILSSForwardSensitivityFunction{iip, sensefunType, senseType, MM} <:
        DiffEqBase.AbstractODEFunction{iip}

--- a/test/forward.jl
+++ b/test/forward.jl
@@ -232,7 +232,7 @@ p = [1.5, 1.0, 3.0, 1.0]
 jac_call_count = 0
 function jac_with_count(J, u, p, t)
     global jac_call_count
-    jac_call_count+=1
+    jac_call_count += 1
     (x, y, a, b, c) = (u[1], u[2], p[1], p[2], p[3])
     J[1, 1] = a + y * b * -1
     J[2, 1] = t * y
@@ -242,8 +242,14 @@ end
 
 f = ODEFunction(fb, jac = jac_with_count, paramjac = paramjac)
 p = [1.5, 1.0, 3.0]
-absolutely_no_ad_sensealg = ForwardSensitivity(autodiff=false, autojacvec=false, autojacmat=false)
-prob = ODEForwardSensitivityProblem(f, [1.0; 1.0], (0.0, 10.0), p, absolutely_no_ad_sensealg)
+absolutely_no_ad_sensealg = ForwardSensitivity(autodiff = false,
+    autojacvec = false,
+    autojacmat = false)
+prob = ODEForwardSensitivityProblem(f,
+    [1.0; 1.0],
+    (0.0, 10.0),
+    p,
+    absolutely_no_ad_sensealg)
 @test SciMLSensitivity.has_original_jac(prob.f)
 @assert jac_call_count == 0
 solve(prob, Tsit5(), abstol = 1e-14, reltol = 1e-14)

--- a/test/forward.jl
+++ b/test/forward.jl
@@ -227,3 +227,24 @@ p = [1.5, 1.0, 3.0, 1.0]
     (0.0,
         10.0),
     p)
+
+# Make sure original jac is actually called if it is passed and autodiff is fully off
+jac_call_count = 0
+function jac_with_count(J, u, p, t)
+    global jac_call_count
+    jac_call_count+=1
+    (x, y, a, b, c) = (u[1], u[2], p[1], p[2], p[3])
+    J[1, 1] = a + y * b * -1
+    J[2, 1] = t * y
+    J[1, 2] = b * x * -1
+    J[2, 2] = t * c * -1 + t * x
+end
+
+f = ODEFunction(fb, jac = jac_with_count, paramjac = paramjac)
+p = [1.5, 1.0, 3.0]
+absolutely_no_ad_sensealg = ForwardSensitivity(autodiff=false, autojacvec=false, autojacmat=false)
+prob = ODEForwardSensitivityProblem(f, [1.0; 1.0], (0.0, 10.0), p, absolutely_no_ad_sensealg)
+@test SciMLSensitivity.has_original_jac(prob.f)
+@assert jac_call_count == 0
+solve(prob, Tsit5(), abstol = 1e-14, reltol = 1e-14)
+@test jac_call_count > 0


### PR DESCRIPTION
It seems to me that this makes more sense as a definition. And that doing it this way, makes my code work.
(though I haven't checked correctness)

Whereas without this, the branch is hit that tries to compute the original jacobian via finite differencing (with `autodiff=false, autojacvec=false, autojacmat=false`)