### PR TITLE
mark a bugfix release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLSensitivity"
 uuid = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "7.36.0"
+version = "7.36.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
I would like a release tagged here.
This has the bugfix #862  but doesn't have the new GaussAdjoint feature.
For some reason newer versions break for me, and I do need to debug it,
but right now I just want to get this release done and come back to that other stuff later.
So a bugfix release would be ideal.

I thought I could just use Manifests to pin my stuff to this, but it makes downstream testing hard.
So better if I can have a release and just pin it with a `~` selector in my project


**Don't Merge this PR to master**
merge it *somewhere else* then tag a release off of it.
(I can't create a branch on this repo)