### PR TITLE
Fix passing vector of times to extract_local_sensitivities

### DIFF
--- a/src/forward_sensitivity.jl
+++ b/src/forward_sensitivity.jl
@@ -542,11 +542,8 @@ function extract_local_sensitivities(tmp, sol, t, asmatrix::Bool)
 end
 
 # Get ODE u vector and sensitivity values from all time points
-function extract_local_sensitivities(sol, ::ForwardSensitivity, ::Val{false})
-    ni = sol.prob.f.numindvar
-    u = sol[1:ni, :]
-    du = [sol[(ni * j + 1):(ni * (j + 1)), :] for j in 1:(sol.prob.f.numparams)]
-    return u, du
+function extract_local_sensitivities(sol, sensealg::ForwardSensitivity, ::Val{false})
+    _extract(sol, sensealg, sol, Val{false}())
 end
 
 function extract_local_sensitivities(sol, ::ForwardDiffSensitivity, ::Val{false})
@@ -597,6 +594,14 @@ function _extract(sol, sensealg::ForwardDiffSensitivity, su::AbstractVector,
     asmatrix::Val = Val(false))
     u = ForwardDiff.value.(su)
     du = _extract_du(sol, sensealg, su, asmatrix)
+    return u, du
+end
+
+function _extract(sol, ::ForwardSensitivity, su::AbstractDiffEqArray,
+    ::Val{false})
+    ni = sol.prob.f.numindvar
+    u = @view su[1:ni, :]
+    du = [@view su[(ni * j + 1):(ni * (j + 1)), :] for j in 1:(sol.prob.f.numparams)]
     return u, du
 end
 

--- a/test/forward.jl
+++ b/test/forward.jl
@@ -106,6 +106,9 @@ sense_res2 = reduce(hcat, dp)
 tmp = similar(sol[1])
 @test extract_local_sensitivities(tmp, sol, sol.t[3]) == extract_local_sensitivities(sol, 3)
 
+_, dp_ts = extract_local_sensitivities(sol, sol.t)
+@test dpall == dp_ts
+
 # asmatrix=true
 @test extract_local_sensitivities(sol, length(sol), true) == (x, sense_res2)
 @test extract_local_sensitivities(sol, sol.t[end], true) == (x, sense_res2)


### PR DESCRIPTION
Closes https://github.com/SciML/SciMLSensitivity.jl/issues/903

not sure there are not other variants of it with other combinations of arguments.
but this is the one I care about, right now.

Basically this change makes the case for taking all the solution's time steps, and the case for taking timesteps that come from interpolation hit the same code path.