### PR TITLE
fix  regression in second order adjoint example

### DIFF
--- a/docs/src/examples/ode/second_order_adjoints.md
+++ b/docs/src/examples/ode/second_order_adjoints.md
@@ -75,7 +75,7 @@ adtype = Optimization.AutoZygote()
 optf = Optimization.OptimizationFunction((x, p) -> loss_neuralode(x), adtype)
 
 optprob1 = Optimization.OptimizationProblem(optf, prob_neuralode.ps)
-pstart = Optimization.solve(optprob1, Adam(0.01), callback = callback, maxiters = 100).u
+pstart = Optimization.solve(optprob1, Optimisers.Adam(0.01), callback = callback, maxiters = 100).u
 
 optprob2 = Optimization.OptimizationProblem(optf, pstart)
 pmin = Optimization.solve(optprob2, NewtonTrustRegion(), callback = callback,


### PR DESCRIPTION
This regressed since last week:
https://buildkite.com/julialang/scimlsensitivity-dot-jl/builds/2548#018d59b5-1f4c-4841-95c2-54027d6fb936/1020-5211