### PR TITLE
ci: rename `DOCUMENTER_KEY` to `TAGBOT_KEY`

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -28,4 +28,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+          ssh: ${{ secrets.TAGBOT_KEY }}


### PR DESCRIPTION
Since Documentation is now built on Buildkite's GPU machines, rename the `DOCUMENTER_KEY` secret to `TAGBOT_KEY`, so it's more consistent, relevant and easier to track.

Note: The secret has also been set up appropriately.