### PR TITLE
fix EnzymeVJP in automatic_sensealg_choice

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -7,7 +7,7 @@ const have_not_warned_vjp = Ref(true)
 const STACKTRACE_WITH_VJPWARN = Ref(false)
 
 function inplace_vjp(prob, u0, p, verbose)
-    du = copy(u0)
+    du = zero(u0)
 
     ez = try
         f = unwrapped_f(prob.f)
@@ -16,8 +16,8 @@ function inplace_vjp(prob, u0, p, verbose)
             f(out, u, _p, t)
             nothing
         end
-        Enzyme.autodiff(Enzyme.Reverse, adfunc, Enzyme.Duplicated(du, du),
-            copy(u0), copy(p), prob.tspan[1])
+        Enzyme.autodiff(Enzyme.Reverse, adfunc, Enzyme.Duplicated(du, copy(u0)),
+            Enzyme.Duplicated(copy(u0), zero(u0)), Enzyme.Duplicated(copy(p), zero(p)), Enzyme.Const(prob.tspan[1]))
         true
     catch e
         if verbose || have_not_warned_vjp[]

--- a/test/automatic_sensealg_choice.jl
+++ b/test/automatic_sensealg_choice.jl
@@ -1,0 +1,21 @@
+using Lux, ComponentArrays, OrdinaryDiffEq, SciMLSensitivity, Zygote, Random
+
+rng = Random.default_rng()
+tspan = (0.0f0, 8.0f0)
+
+ann = Chain(Dense(1, 32, tanh), Dense(32, 32, tanh), Dense(32, 1))
+ps, st = Lux.setup(rng, ann)
+p = ComponentArray(ps)
+
+θ, ax = getdata(p), getaxes(p)
+
+function dxdt_(dx, x, p, t)
+    ps = ComponentArray(p, ax)
+    x1, x2 = x
+    dx[1] = x[2]
+    dx[2] = first(ann([t], ps, st))[1]^3
+end
+x0 = [-4.0f0, 0.0f0]
+ts = Float32.(collect(0.0:0.01:tspan[2]))
+prob = ODEProblem(dxdt_, x0, tspan, θ)
+SciMLSensitivity.automatic_sensealg_choice(prob, x0, θ, true) == InterpolatingAdjoint{0, true, Val{:central}, EnzymeVJP}(EnzymeVJP(0), false, false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,7 +44,7 @@ end
     if GROUP == "All" || GROUP == "Core3" || GROUP == "Downstream"
         @testset "Core 3" begin
             @time @safetestset "Adjoint Sensitivity" include("adjoint.jl")
-
+            @time @safetestset "automatic sensealg choice" include("automatic_sensealg_choice.jl")
             @time @safetestset "Physical ODE Adjoint Regression Test" include("physical_ode_regression.jl")
 
             @time @safetestset "Continuous adjoint params" include("adjoint_param.jl")


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

The `automatic_sensealg_choice rejects` `EnzymeVJP` often, even though specifying it manually works.