### PR TITLE
Fix Gauss integrand sign change for DiffEqCallbacks change

### DIFF
--- a/src/gauss_adjoint.jl
+++ b/src/gauss_adjoint.jl
@@ -490,6 +490,7 @@ function (S::GaussIntegrand)(out, t, λ)
         y = sol(t)
     end
     vec_pjac!(out, λ, y, t, S)
+    out .*= -1
     if S.dgdp !== nothing
         S.dgdp(dgdp_cache, y, p, t)
         out .+= dgdp_cache


### PR DESCRIPTION
Required change from https://github.com/SciML/DiffEqCallbacks.jl/pull/209