### PR TITLE
chore: move `literal_getproperty` adjoint to SciMLSensitivity

### DIFF
--- a/src/SciMLSensitivity.jl
+++ b/src/SciMLSensitivity.jl
@@ -37,7 +37,8 @@ import SciMLBase: unwrapped_f, _unwrap_val
 import SciMLBase: AbstractOverloadingSensitivityAlgorithm, AbstractSensitivityAlgorithm,
                   AbstractForwardSensitivityAlgorithm, AbstractAdjointSensitivityAlgorithm,
                   AbstractSecondOrderSensitivityAlgorithm,
-                  AbstractShadowingSensitivityAlgorithm
+                  AbstractShadowingSensitivityAlgorithm,
+                  AbstractTimeSeriesSolution
 
 include("parameters_handling.jl")
 include("sensitivity_algorithms.jl")

--- a/src/SciMLSensitivity.jl
+++ b/src/SciMLSensitivity.jl
@@ -38,7 +38,7 @@ import SciMLBase: AbstractOverloadingSensitivityAlgorithm, AbstractSensitivityAl
                   AbstractForwardSensitivityAlgorithm, AbstractAdjointSensitivityAlgorithm,
                   AbstractSecondOrderSensitivityAlgorithm,
                   AbstractShadowingSensitivityAlgorithm,
-                  AbstractTimeSeriesSolution
+                  AbstractTimeseriesSolution
 
 include("parameters_handling.jl")
 include("sensitivity_algorithms.jl")

--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -657,7 +657,7 @@ Zygote.@adjoint function Zygote.literal_getproperty(sol::AbstractTimeseriesSolut
     function solu_adjoint(Δ)
         zerou = zero(sol.prob.u0)
         _Δ = @. ifelse(Δ === nothing, (zerou,), Δ)
-        (build_solution(sol.prob, sol.alg, sol.t, _Δ),)
+        (SciMLBase.build_solution(sol.prob, sol.alg, sol.t, _Δ),)
     end
     sol.u, solu_adjoint
 end

--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -651,3 +651,13 @@ function out_and_ts(_ts, duplicate_iterator_times, sol)
     end
     return out, ts
 end
+
+Zygote.@adjoint function Zygote.literal_getproperty(sol::AbstractTimeseriesSolution,
+        ::Val{:u})
+    function solu_adjoint(Δ)
+        zerou = zero(sol.prob.u0)
+        _Δ = @. ifelse(Δ === nothing, (zerou,), Δ)
+        (build_solution(sol.prob, sol.alg, sol.t, _Δ),)
+    end
+    sol.u, solu_adjoint
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Moves the `literal_getproperty` from SciMLBase to here to make it easier to remove in the future in favour of structural tangents. These are necessary to make it possible to accumulate gradients against parameters.

Add any other context about the problem here.
