### PR TITLE
Fence definition of `literal_getproperty` adjoint

### DIFF
--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -652,12 +652,15 @@ function out_and_ts(_ts, duplicate_iterator_times, sol)
     return out, ts
 end
 
-Zygote.@adjoint function Zygote.literal_getproperty(sol::AbstractTimeseriesSolution,
-        ::Val{:u})
-    function solu_adjoint(Δ)
-        zerou = zero(sol.prob.u0)
-        _Δ = @. ifelse(Δ === nothing, (zerou,), Δ)
-        (SciMLBase.build_solution(sol.prob, sol.alg, sol.t, _Δ),)
+if !hasmethod(Zygote.adjoint, Tuple{Zygote.AContext, typeof(Zygote.literal_getproperty), SciMLBase.AbstractTimeseriesSolution, Val{:u}})
+    Zygote.@adjoint function Zygote.literal_getproperty(sol::AbstractTimeseriesSolution,
+            ::Val{:u})
+        function solu_adjoint(Δ)
+            zerou = zero(sol.prob.u0)
+            _Δ = @. ifelse(Δ === nothing, (zerou,), Δ)
+            (SciMLBase.build_solution(sol.prob, sol.alg, sol.t, _Δ),)
+        end
+        @show "here"
+        sol.u, solu_adjoint
     end
-    sol.u, solu_adjoint
 end

--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -652,7 +652,9 @@ function out_and_ts(_ts, duplicate_iterator_times, sol)
     return out, ts
 end
 
-if !hasmethod(Zygote.adjoint, Tuple{Zygote.AContext, typeof(Zygote.literal_getproperty), SciMLBase.AbstractTimeseriesSolution, Val{:u}})
+if !hasmethod(Zygote.adjoint,
+    Tuple{Zygote.AContext, typeof(Zygote.literal_getproperty),
+        SciMLBase.AbstractTimeseriesSolution, Val{:u}})
     Zygote.@adjoint function Zygote.literal_getproperty(sol::AbstractTimeseriesSolution,
             ::Val{:u})
         function solu_adjoint(Δ)

--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -660,7 +660,6 @@ if !hasmethod(Zygote.adjoint, Tuple{Zygote.AContext, typeof(Zygote.literal_getpr
             _Δ = @. ifelse(Δ === nothing, (zerou,), Δ)
             (SciMLBase.build_solution(sol.prob, sol.alg, sol.t, _Δ),)
         end
-        @show "here"
         sol.u, solu_adjoint
     end
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Closes https://github.com/SciML/SciMLSensitivity.jl/issues/1058
There are no new symbols added in #1056 , so it is not possible to check with `isdefined`. Likewise, there are no new symbols when an adjoint is defined, only methods to a method table. This PR adds a check for the existence of that `literal_getproperty(::AbstractTimeseriesSolution, ::Val{:u})` method and skips the adjoint if it exists. 

Add any other context about the problem here.
