### PR TITLE
Safety make_zero! on repeated Enzyme calls with caches

### DIFF
--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -162,7 +162,7 @@ function _track_callback(cb::VectorContinuousCallback, t, u, p, sensealg)
         cb.dtrelax, cb.abstol, cb.reltol, cb.repeat_nudge)
 end
 
-struct FakeIntegrator{uType, P, tType, tprevType}
+mutable struct FakeIntegrator{uType, P, tType, tprevType}
     u::uType
     p::P
     t::tType

--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -382,20 +382,20 @@ end
 function setup_w_wp(cb::Union{DiscreteCallback, ContinuousCallback},
         autojacvec::Union{ReverseDiffVJP, EnzymeVJP}, pos_neg, event_idx,
         tprev)
-    w = let tprev = tprev, pos_neg = pos_neg
+    w = let _tprev = Ref(tprev), pos_neg = pos_neg
         function (du, u, p, t)
             _affect! = get_affect!(cb, pos_neg)
-            fakeinteg = get_FakeIntegrator(autojacvec, u, p, t, tprev)
+            fakeinteg = get_FakeIntegrator(autojacvec, u, p, t, _tprev[])
             _affect!(fakeinteg)
             du .= fakeinteg.u
             nothing
         end
     end
 
-    wp = let tprev = tprev, pos_neg = pos_neg
+    wp = let _tprev = Ref(tprev), pos_neg = pos_neg
         function (dp, p, u, t)
             _affect! = get_affect!(cb, pos_neg)
-            fakeinteg = get_FakeIntegrator(autojacvec, u, p, t, tprev)
+            fakeinteg = get_FakeIntegrator(autojacvec, u, p, t, _tprev[])
             _affect!(fakeinteg)
             dp .= fakeinteg.p
             nothing
@@ -407,20 +407,20 @@ end
 function setup_w_wp(cb::VectorContinuousCallback,
         autojacvec::Union{ReverseDiffVJP, EnzymeVJP}, pos_neg, event_idx,
         tprev)
-    w = let tprev = tprev, pos_neg = pos_neg, event_idx = event_idx
+    w = let _tprev = Ref(tprev), pos_neg = pos_neg, event_idx = event_idx
         function (du, u, p, t)
             _affect! = get_affect!(cb, pos_neg)
-            fakeinteg = get_FakeIntegrator(autojacvec, u, p, t, tprev)
+            fakeinteg = get_FakeIntegrator(autojacvec, u, p, t, _tprev[])
             _affect!(fakeinteg, event_idx)
             du .= fakeinteg.u
             nothing
         end
     end
 
-    wp = let tprev = tprev, pos_neg = pos_neg, event_idx = event_idx
+    wp = let _tprev = Ref(tprev), pos_neg = pos_neg, event_idx = event_idx
         function (dp, p, u, t)
             _affect! = get_affect!(cb, pos_neg)
-            fakeinteg = get_FakeIntegrator(autojacvec, u, p, t, tprev)
+            fakeinteg = get_FakeIntegrator(autojacvec, u, p, t, _tprev[])
             _affect!(fakeinteg, event_idx)
             dp .= fakeinteg.p
             nothing

--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -162,7 +162,7 @@ function _track_callback(cb::VectorContinuousCallback, t, u, p, sensealg)
         cb.dtrelax, cb.abstol, cb.reltol, cb.repeat_nudge)
 end
 
-mutable struct FakeIntegrator{uType, P, tType, tprevType}
+struct FakeIntegrator{uType, P, tType, tprevType}
     u::uType
     p::P
     t::tType

--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -382,20 +382,20 @@ end
 function setup_w_wp(cb::Union{DiscreteCallback, ContinuousCallback},
         autojacvec::Union{ReverseDiffVJP, EnzymeVJP}, pos_neg, event_idx,
         tprev)
-    w = let _tprev = Ref(tprev), pos_neg = pos_neg
+    w = let tprev = tprev, pos_neg = pos_neg
         function (du, u, p, t)
             _affect! = get_affect!(cb, pos_neg)
-            fakeinteg = get_FakeIntegrator(autojacvec, u, p, t, _tprev[])
+            fakeinteg = get_FakeIntegrator(autojacvec, u, p, t, tprev)
             _affect!(fakeinteg)
             du .= fakeinteg.u
             nothing
         end
     end
 
-    wp = let _tprev = Ref(tprev), pos_neg = pos_neg
+    wp = let tprev = tprev, pos_neg = pos_neg
         function (dp, p, u, t)
             _affect! = get_affect!(cb, pos_neg)
-            fakeinteg = get_FakeIntegrator(autojacvec, u, p, t, _tprev[])
+            fakeinteg = get_FakeIntegrator(autojacvec, u, p, t, tprev)
             _affect!(fakeinteg)
             dp .= fakeinteg.p
             nothing
@@ -407,20 +407,20 @@ end
 function setup_w_wp(cb::VectorContinuousCallback,
         autojacvec::Union{ReverseDiffVJP, EnzymeVJP}, pos_neg, event_idx,
         tprev)
-    w = let _tprev = Ref(tprev), pos_neg = pos_neg, event_idx = event_idx
+    w = let tprev = tprev, pos_neg = pos_neg, event_idx = event_idx
         function (du, u, p, t)
             _affect! = get_affect!(cb, pos_neg)
-            fakeinteg = get_FakeIntegrator(autojacvec, u, p, t, _tprev[])
+            fakeinteg = get_FakeIntegrator(autojacvec, u, p, t, tprev)
             _affect!(fakeinteg, event_idx)
             du .= fakeinteg.u
             nothing
         end
     end
 
-    wp = let _tprev = Ref(tprev), pos_neg = pos_neg, event_idx = event_idx
+    wp = let tprev = tprev, pos_neg = pos_neg, event_idx = event_idx
         function (dp, p, u, t)
             _affect! = get_affect!(cb, pos_neg)
-            fakeinteg = get_FakeIntegrator(autojacvec, u, p, t, _tprev[])
+            fakeinteg = get_FakeIntegrator(autojacvec, u, p, t, tprev)
             _affect!(fakeinteg, event_idx)
             dp .= fakeinteg.p
             nothing

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -1691,7 +1691,7 @@ function DiffEqBase._concrete_solve_adjoint(prob::SciMLBase.AbstractODEProblem, 
                     vec(@view(_out[_save_idxs])) .= vec(x[_save_idxs])
                 end
             else
-                Δ = Δ isa Tangent ? Δ.u : Δ
+                Δ = Δ isa Tangent ? unthunk(Δ.u) : Δ
                 if _save_idxs isa Number
                     _out[_save_idxs] = adapt(ArrayInterface.parameterless_type(u0),
                         reshape(Δ, prod(size(Δ)[1:(end - 1)]),

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -1681,8 +1681,8 @@ function DiffEqBase._concrete_solve_adjoint(prob::SciMLBase.AbstractODEProblem, 
 
     function adjoint_sensitivity_backpass(Δ)
         function df(_out, u, p, t, i)
-            if Δ isa AbstractArray{<:AbstractArray} || Δ isa AbstractVectorOfArray
-                x = Δ isa AbstractVectorOfArray ? Δ.u[i] : Δ[i]
+            if Δ isa AbstractArray{<:AbstractArray}  Δ isa AbstractVectorOfArray || Δ isa Tangent
+                x = (Δ isa AbstractVectorOfArray || Δ isa Tangent) ? unthunk(Δ.u[i]) : Δ[i]
                 if _save_idxs isa Number
                     _out[_save_idxs] = x[_save_idxs]
                 elseif _save_idxs isa Colon
@@ -1691,7 +1691,6 @@ function DiffEqBase._concrete_solve_adjoint(prob::SciMLBase.AbstractODEProblem, 
                     vec(@view(_out[_save_idxs])) .= vec(x[_save_idxs])
                 end
             else
-                Δ = Δ isa Tangent ? unthunk(Δ.u) : Δ
                 if _save_idxs isa Number
                     _out[_save_idxs] = adapt(ArrayInterface.parameterless_type(u0),
                         reshape(Δ, prod(size(Δ)[1:(end - 1)]),

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -578,7 +578,7 @@ function DiffEqBase._concrete_solve_adjoint(
                     (Δu[i] isa NoTangent || eltype(Δu) <: NoTangent) && return
                 if Δ isa AbstractArray{<:AbstractArray} || Δ isa AbstractVectorOfArray ||
                    Δ isa Tangent
-                    x = (Δ isa AbstractVectorOfArray || Δ isa Tangent) ? Δu[i] : Δ[i]
+                    x = Δ isa AbstractVectorOfArray ? Δu.u[i] : (Δ isa Tangent ? Δu[i] : Δ[i])
                     if _save_idxs isa Number
                         _out[_save_idxs] = x[_save_idxs]
                     elseif _save_idxs isa Colon
@@ -1691,6 +1691,7 @@ function DiffEqBase._concrete_solve_adjoint(prob::SciMLBase.AbstractODEProblem, 
                     vec(@view(_out[_save_idxs])) .= vec(x[_save_idxs])
                 end
             else
+                Δ = Δ isa Tangent ? Δ.u : Δ
                 if _save_idxs isa Number
                     _out[_save_idxs] = adapt(ArrayInterface.parameterless_type(u0),
                         reshape(Δ, prod(size(Δ)[1:(end - 1)]),

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -707,7 +707,8 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::EnzymeVJP, dgrad, 
     #if dy !== nothing
     #      tmp3 = dy
     #else
-    Enzyme.make_zero!(tmp3)
+    tmp3 .= 0
+    #Enzyme.make_zero!(tmp3)
     #end
 
     vec(tmp4) .= vec(λ)

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -715,16 +715,11 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::EnzymeVJP, dgrad, 
 
     isautojacvec = get_jacvec(sensealg)
 
-    if Core.Compiler.isconstType(_tmp6)
-        Enzyme.make_zero!(_tmp6)
-        _f = Enzyme.Duplicated(S.diffcache.pf, _tmp6)
-    else
-        _f = S.diffcache.pf
-    end
+    Enzyme.make_zero!(_tmp6)
 
     if inplace_sensitivity(S)
         if W === nothing
-            Enzyme.autodiff(Enzyme.Reverse, _f,
+            Enzyme.autodiff(Enzyme.Reverse, Enzyme.Duplicated(S.diffcache.pf, _tmp6),
                 Enzyme.Const, Enzyme.Duplicated(tmp3, tmp4),
                 Enzyme.Duplicated(ytmp, tmp1),
                 dup,

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -715,11 +715,16 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::EnzymeVJP, dgrad, 
 
     isautojacvec = get_jacvec(sensealg)
 
-    Enzyme.make_zero!(_tmp6)
+    if Core.Compiler.isconstType(_tmp6)
+        Enzyme.make_zero!(_tmp6)
+        _f = Enzyme.Duplicated(S.diffcache.pf, _tmp6)
+    else
+        _f = S.diffcache.pf
+    end
 
     if inplace_sensitivity(S)
         if W === nothing
-            Enzyme.autodiff(Enzyme.Reverse, Enzyme.Duplicated(S.diffcache.pf, _tmp6),
+            Enzyme.autodiff(Enzyme.Reverse, _f,
                 Enzyme.Const, Enzyme.Duplicated(tmp3, tmp4),
                 Enzyme.Duplicated(ytmp, tmp1),
                 dup,

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -714,6 +714,8 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::EnzymeVJP, dgrad, 
 
     isautojacvec = get_jacvec(sensealg)
 
+    Enzyme.make_zero!(_tmp6)
+
     if inplace_sensitivity(S)
         if W === nothing
             Enzyme.autodiff(Enzyme.Reverse, Enzyme.Duplicated(S.diffcache.pf, _tmp6),

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -707,15 +707,17 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::EnzymeVJP, dgrad, 
     #if dy !== nothing
     #      tmp3 = dy
     #else
-    tmp3 .= 0
-    #Enzyme.make_zero!(tmp3)
+    Enzyme.make_zero!(tmp3)
     #end
 
     vec(tmp4) .= vec(λ)
 
     isautojacvec = get_jacvec(sensealg)
 
-    Enzyme.make_zero!(_tmp6)
+    # Correctness over speed
+    # TODO: Get a fix for `make_zero!` to allow reusing zero'd memory
+    # https://github.com/EnzymeAD/Enzyme.jl/issues/2400
+    _tmp6 = Enzyme.make_zero(_tmp6)
 
     if inplace_sensitivity(S)
         if W === nothing

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -689,7 +689,7 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::EnzymeVJP, dgrad, 
         ytmp = _tmp5
     end
 
-    tmp1 .= 0 # should be removed for dλ
+    Enzyme.make_zero!(tmp1) # should be removed for dλ
     vec(ytmp) .= vec(y)
 
     #if dgrad !== nothing
@@ -707,7 +707,7 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::EnzymeVJP, dgrad, 
     #if dy !== nothing
     #      tmp3 = dy
     #else
-    tmp3 .= 0
+    Enzyme.make_zero!(tmp3)
     #end
 
     vec(tmp4) .= vec(λ)

--- a/src/gauss_adjoint.jl
+++ b/src/gauss_adjoint.jl
@@ -501,6 +501,7 @@ function vec_pjac!(out, λ, y, t, S::GaussIntegrand)
         vtmp4 = vec(tmp4)
         vtmp4 .= λ
         out .= 0
+        Enzyme.make_zero!(tmp6)
         Enzyme.autodiff(
             Enzyme.Reverse, Enzyme.Duplicated(pf, tmp6), Enzyme.Const,
             Enzyme.Duplicated(tmp3, tmp4),

--- a/src/gauss_adjoint.jl
+++ b/src/gauss_adjoint.jl
@@ -501,7 +501,12 @@ function vec_pjac!(out, λ, y, t, S::GaussIntegrand)
         vtmp4 = vec(tmp4)
         vtmp4 .= λ
         Enzyme.make_zero!(out)
-        Enzyme.make_zero!(tmp6)
+
+        # Correctness over speed
+        # TODO: Get a fix for `make_zero!` to allow reusing zero'd memory
+        # https://github.com/EnzymeAD/Enzyme.jl/issues/2400
+        tmp6 = Enzyme.make_zero(tmp6)
+        
         Enzyme.autodiff(
             Enzyme.Reverse, Enzyme.Duplicated(pf, tmp6), Enzyme.Const,
             Enzyme.Duplicated(tmp3, tmp4),

--- a/src/gauss_adjoint.jl
+++ b/src/gauss_adjoint.jl
@@ -500,7 +500,7 @@ function vec_pjac!(out, λ, y, t, S::GaussIntegrand)
         tmp3, tmp4, tmp6 = paramjac_config
         vtmp4 = vec(tmp4)
         vtmp4 .= λ
-        out .= 0
+        Enzyme.make_zero!(out)
         Enzyme.make_zero!(tmp6)
         Enzyme.autodiff(
             Enzyme.Reverse, Enzyme.Duplicated(pf, tmp6), Enzyme.Const,

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -301,7 +301,11 @@ function vec_pjac!(out, λ, y, t, S::AdjointSensitivityIntegrand)
         vtmp4 = vec(tmp4)
         vtmp4 .= λ
         Enzyme.make_zero!(out)
-        Enzyme.make_zero!(tmp6)
+
+        # Correctness over speed
+        # TODO: Get a fix for `make_zero!` to allow reusing zero'd memory
+        # https://github.com/EnzymeAD/Enzyme.jl/issues/2400
+        tmp6 = Enzyme.make_zero(tmp6)
         Enzyme.autodiff(
             Enzyme.Reverse, Enzyme.Duplicated(pf, tmp6), Enzyme.Const,
             Enzyme.Duplicated(tmp3, tmp4),

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -300,7 +300,7 @@ function vec_pjac!(out, λ, y, t, S::AdjointSensitivityIntegrand)
         tmp3, tmp4, tmp6 = paramjac_config
         vtmp4 = vec(tmp4)
         vtmp4 .= λ
-        out .= 0
+        Enzyme.make_zero!(out)
         Enzyme.make_zero!(tmp6)
         Enzyme.autodiff(
             Enzyme.Reverse, Enzyme.Duplicated(pf, tmp6), Enzyme.Const,

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -301,6 +301,7 @@ function vec_pjac!(out, λ, y, t, S::AdjointSensitivityIntegrand)
         vtmp4 = vec(tmp4)
         vtmp4 .= λ
         out .= 0
+        Enzyme.make_zero!(tmp6)
         Enzyme.autodiff(
             Enzyme.Reverse, Enzyme.Duplicated(pf, tmp6), Enzyme.Const,
             Enzyme.Duplicated(tmp3, tmp4),

--- a/test/hybrid_de.jl
+++ b/test/hybrid_de.jl
@@ -51,4 +51,4 @@ end
 res = solve(OptimizationProblem(OptimizationFunction(loss_n_ode, AutoZygote()),
         ps),
     Adam(0.05); callback = cba, maxiters = 200)
-@test loss_n_ode(res.u, nothing) < 0.4
+@test loss_n_ode(res.u, nothing) < 0.5


### PR DESCRIPTION
This should ensure that the caches are always zero'd for the derivatives.
