### PR TITLE
docs: Make example code consistent with text

### DIFF
--- a/docs/src/tutorials/adjoint_continuous_functional.md
+++ b/docs/src/tutorials/adjoint_continuous_functional.md
@@ -67,15 +67,15 @@ G(u,p)=\int_{0}^{T}\frac{\sum_{i=1}^{n}u_{i}^{2}(t)}{2}dt
 which is:
 
 ```@example continuousadjoint
-g(u, p, t) = (sum(u) .^ 2) ./ 2
+g(u, p, t) = sum(u .^ 2) ./ 2
 ```
 
 Notice that the gradient of this function with respect to the state `u` is:
 
 ```@example continuousadjoint
 function dg(out, u, p, t)
-    out[1] = u[1] + u[2]
-    out[2] = u[1] + u[2]
+    out[1] = u[1]
+    out[2] = u[2]
 end
 ```
 
@@ -96,7 +96,7 @@ using QuadGK, ForwardDiff, Calculus
 function G(p)
     tmp_prob = remake(prob, p = p)
     sol = solve(tmp_prob, Vern9(), abstol = 1e-14, reltol = 1e-14)
-    res, err = quadgk((t) -> (sum(sol(t)) .^ 2) ./ 2, 0.0, 10.0, atol = 1e-14, rtol = 1e-10)
+    res, err = quadgk((t) -> sum(sol(t) .^ 2) ./ 2, 0.0, 10.0, atol = 1e-14, rtol = 1e-10)
     res
 end
 res2 = ForwardDiff.gradient(G, [1.5, 1.0, 3.0])


### PR DESCRIPTION
The text in the section ["Example: Continuous Adjoints on an Energy Functional"](https://docs.sciml.ai/SciMLSensitivity/stable/tutorials/adjoint_continuous_functional/#Example:-Continuous-Adjoints-on-an-Energy-Functional) does not agree with the code.  Specifically, it's describing the *energy functional* — in the title and the text — which I think we would all agree should be the sum of the squares.  In fact, the text actually gives that formula as displayed latex.  But the code consistently uses the square of the sum.  This PR corrects the code.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  