### PR TITLE
Remove duplicate callbacks in ForwardDiff and ReverseDiff adjoints

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -775,7 +775,6 @@ function DiffEqBase._concrete_solve_adjoint(
         u0, p, originator::SciMLBase.ADOriginator,
         args...; saveat = eltype(prob.tspan)[],
         kwargs...) where {CS, CTS}
-    
     if !(p isa Union{Nothing, SciMLBase.NullParameters, AbstractArray}) ||
        (p isa AbstractArray && !Base.isconcretetype(eltype(p)))
         throw(ForwardDiffSensitivityParameterCompatibilityError())
@@ -786,9 +785,10 @@ function DiffEqBase._concrete_solve_adjoint(
     else
         _saveat = saveat
     end
-    
+
     # use the callback in kwargs, not prob
-    sol = solve(remake(prob, p = p, u0 = u0, callback = nothing), alg, args...; saveat = _saveat, kwargs...)
+    sol = solve(remake(prob, p = p, u0 = u0, callback = nothing),
+        alg, args...; saveat = _saveat, kwargs...)
 
     # saveat values
     # need all values here. Not only unique ones.
@@ -869,7 +869,7 @@ function DiffEqBase._concrete_solve_adjoint(
 
                     # use the callback from kwargs, not prob
                     _prob = remake(prob, f = _f, u0 = u0dual, p = pdual,
-                            tspan = tspandual, callback = nothing)
+                        tspan = tspandual, callback = nothing)
 
                     if _prob isa SDEProblem
                         _prob.noise_rate_prototype !== nothing && (_prob = remake(_prob,
@@ -1026,8 +1026,7 @@ function DiffEqBase._concrete_solve_adjoint(
 
                 # use the callback from kwargs, not prob
                 _prob = remake(prob, f = _f, u0 = u0dual, p = pdual,
-                        tspan = tspandual, callback = nothing)
-
+                    tspan = tspandual, callback = nothing)
 
                 if _prob isa SDEProblem
                     _prob.noise_rate_prototype !== nothing && (_prob = remake(_prob,
@@ -1044,7 +1043,7 @@ function DiffEqBase._concrete_solve_adjoint(
                 _sol = solve(_prob, alg, args...; saveat = ts, kwargs...)
                 _, du = extract_local_sensitivities(_sol, sensealg, Val(true))
 
-                if haskey(kwargs, :callback) 
+                if haskey(kwargs, :callback)
                     # handle bounds errors: ForwardDiffSensitivity uses dual numbers, so there
                     # can be more or less time points in the primal solution
                     # than in the solution using dual numbers when adaptive solvers are used.

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -682,7 +682,8 @@ function DiffEqBase._concrete_solve_adjoint(prob::SciMLBase.AbstractODEProblem, 
     end
 
     # callback = nothing ensures only the callback in kwargs is used
-    _prob = ODEForwardSensitivityProblem(_f, u0, prob.tspan, p, sensealg, callback = nothing)
+    _prob = ODEForwardSensitivityProblem(
+        _f, u0, prob.tspan, p, sensealg, callback = nothing)
     sol = solve(_prob, alg, args...; kwargs...)
     _, du = extract_local_sensitivities(sol, sensealg, Val(true))
     ts = current_time(sol)
@@ -730,7 +731,8 @@ function DiffEqBase._concrete_solve_forward(prob::SciMLBase.AbstractODEProblem, 
         u0, p, originator::SciMLBase.ADOriginator,
         args...; save_idxs = nothing,
         kwargs...)
-    _prob = ODEForwardSensitivityProblem(prob.f, u0, prob.tspan, p, sensealg, callback = nothing)
+    _prob = ODEForwardSensitivityProblem(
+        prob.f, u0, prob.tspan, p, sensealg, callback = nothing)
     sol = solve(_prob, args...; kwargs...)
     u, du = extract_local_sensitivities(sol, Val(true))
     _save_idxs = save_idxs === nothing ? (1:length(u0)) : save_idxs

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -1214,9 +1214,9 @@ function DiffEqBase._concrete_solve_adjoint(
                (prob.f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper ||
                 SciMLBase.specialization(prob.f) === SciMLBase.AutoSpecialize)
                 f = ODEFunction{isinplace(prob), SciMLBase.FullSpecialize}(unwrapped_f(prob.f))
-                _prob = remake(prob, f = f, u0 = map(identity, _u0), p = _p, tspan = _tspan)
+                _prob = remake(prob, f = f, u0 = map(identity, _u0), p = _p, tspan = _tspan, callback = nothing)
             else
-                _prob = remake(prob, u0 = map(identity, _u0), p = _p, tspan = _tspan)
+                _prob = remake(prob, u0 = map(identity, _u0), p = _p, tspan = _tspan, callback = nothing)
             end
         else
             # use TrackedArray for efficiency of the tape
@@ -1247,13 +1247,13 @@ function DiffEqBase._concrete_solve_adjoint(
                             SciMLBase.FullSpecialize
                         }(_f,
                             _g),
-                        u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p), tspan = _tspan)
+                        u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p), tspan = _tspan, callback = nothing)
                 else
                     _prob = remake(prob,
                         f = DiffEqBase.parameterless_type(prob.f){false,
                             SciMLBase.FullSpecialize
                         }(_f),
-                        u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p), tspan = _tspan)
+                        u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p), tspan = _tspan, callback = nothing)
                 end
             elseif prob isa
                    Union{SciMLBase.AbstractODEProblem, SciMLBase.AbstractSDEProblem}
@@ -1279,13 +1279,13 @@ function DiffEqBase._concrete_solve_adjoint(
                             SciMLBase.FullSpecialize
                         }(_f,
                             _g),
-                        u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p), tspan = _tspan)
+                        u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p), tspan = _tspan, callback = nothing)
                 else
                     _prob = remake(prob,
                         f = DiffEqBase.parameterless_type(prob.f){false,
                             SciMLBase.FullSpecialize
                         }(_f),
-                        u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p), tspan = _tspan)
+                        u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p), tspan = _tspan, callback = nothing)
                 end
             else
                 error("TrackerAdjont does not currently support the specified problem type. Please open an issue.")

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -681,7 +681,8 @@ function DiffEqBase._concrete_solve_adjoint(prob::SciMLBase.AbstractODEProblem, 
         prob.f
     end
 
-    _prob = ODEForwardSensitivityProblem(_f, u0, prob.tspan, p, sensealg)
+    # callback = nothing ensures only the callback in kwargs is used
+    _prob = ODEForwardSensitivityProblem(_f, u0, prob.tspan, p, sensealg, callback = nothing)
     sol = solve(_prob, alg, args...; kwargs...)
     _, du = extract_local_sensitivities(sol, sensealg, Val(true))
     ts = current_time(sol)
@@ -729,7 +730,7 @@ function DiffEqBase._concrete_solve_forward(prob::SciMLBase.AbstractODEProblem, 
         u0, p, originator::SciMLBase.ADOriginator,
         args...; save_idxs = nothing,
         kwargs...)
-    _prob = ODEForwardSensitivityProblem(prob.f, u0, prob.tspan, p, sensealg)
+    _prob = ODEForwardSensitivityProblem(prob.f, u0, prob.tspan, p, sensealg, callback = nothing)
     sol = solve(_prob, args...; kwargs...)
     u, du = extract_local_sensitivities(sol, Val(true))
     _save_idxs = save_idxs === nothing ? (1:length(u0)) : save_idxs

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -1214,9 +1214,11 @@ function DiffEqBase._concrete_solve_adjoint(
                (prob.f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper ||
                 SciMLBase.specialization(prob.f) === SciMLBase.AutoSpecialize)
                 f = ODEFunction{isinplace(prob), SciMLBase.FullSpecialize}(unwrapped_f(prob.f))
-                _prob = remake(prob, f = f, u0 = map(identity, _u0), p = _p, tspan = _tspan, callback = nothing)
+                _prob = remake(prob, f = f, u0 = map(identity, _u0),
+                    p = _p, tspan = _tspan, callback = nothing)
             else
-                _prob = remake(prob, u0 = map(identity, _u0), p = _p, tspan = _tspan, callback = nothing)
+                _prob = remake(prob, u0 = map(identity, _u0), p = _p,
+                    tspan = _tspan, callback = nothing)
             end
         else
             # use TrackedArray for efficiency of the tape
@@ -1247,13 +1249,15 @@ function DiffEqBase._concrete_solve_adjoint(
                             SciMLBase.FullSpecialize
                         }(_f,
                             _g),
-                        u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p), tspan = _tspan, callback = nothing)
+                        u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p),
+                        tspan = _tspan, callback = nothing)
                 else
                     _prob = remake(prob,
                         f = DiffEqBase.parameterless_type(prob.f){false,
                             SciMLBase.FullSpecialize
                         }(_f),
-                        u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p), tspan = _tspan, callback = nothing)
+                        u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p),
+                        tspan = _tspan, callback = nothing)
                 end
             elseif prob isa
                    Union{SciMLBase.AbstractODEProblem, SciMLBase.AbstractSDEProblem}
@@ -1279,13 +1283,15 @@ function DiffEqBase._concrete_solve_adjoint(
                             SciMLBase.FullSpecialize
                         }(_f,
                             _g),
-                        u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p), tspan = _tspan, callback = nothing)
+                        u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p),
+                        tspan = _tspan, callback = nothing)
                 else
                     _prob = remake(prob,
                         f = DiffEqBase.parameterless_type(prob.f){false,
                             SciMLBase.FullSpecialize
                         }(_f),
-                        u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p), tspan = _tspan, callback = nothing)
+                        u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p),
+                        tspan = _tspan, callback = nothing)
                 end
             else
                 error("TrackerAdjont does not currently support the specified problem type. Please open an issue.")

--- a/test/prob_kwargs.jl
+++ b/test/prob_kwargs.jl
@@ -54,4 +54,3 @@ u0p = [2.0, 3.0]
 
 @test f1(u0p) == f2(u0p)
 @test Zygote.gradient(f1, u0p)[1] == Zygote.gradient(f2, u0p)[1]
-

--- a/test/prob_kwargs.jl
+++ b/test/prob_kwargs.jl
@@ -52,12 +52,14 @@ let callback_count1 = 0, callback_count2 = 0
         sum(solve(prob, Tsit5(), tstops = [0.5], callback = cb, sensealg = adjoint_type))
     end
 
-    adjoint_list = [ForwardDiffSensitivity(), ReverseDiffAdjoint(), TrackerAdjoint()]
-    @testset for adjoint_type in adjoint_list
-        u0p = [2.0, 3.0]
-        Zygote.gradient(x -> f1(x, adjoint_type), u0p)
-        Zygote.gradient(x -> f2(x, adjoint_type), u0p)
+    @testset "Callback duplication check" begin
+        for adjoint_type in [
+            ForwardDiffSensitivity(), ReverseDiffAdjoint(), TrackerAdjoint()]
+            u0p = [2.0, 3.0]
+            Zygote.gradient(x -> f1(x, adjoint_type), u0p)
+            Zygote.gradient(x -> f2(x, adjoint_type), u0p)
 
-        @test callback_count1 == callback_count2
+            @test callback_count1 == callback_count2
+        end
     end
 end

--- a/test/prob_kwargs.jl
+++ b/test/prob_kwargs.jl
@@ -60,9 +60,11 @@ let callback_count1 = 0, callback_count2 = 0
             count1 = 0
             count2 = 0
             if adjoint_type == GaussAdjoint()
-                @test_broken Zygote.gradient(x -> f1(x, adjoint_type), u0p) == Zygote.gradient(x -> f2(x, adjoint_type), u0p)
+                @test_broken Zygote.gradient(x -> f1(x, adjoint_type), u0p) ==
+                             Zygote.gradient(x -> f2(x, adjoint_type), u0p)
             else
-                @test Zygote.gradient(x -> f1(x, adjoint_type), u0p) == Zygote.gradient(x -> f2(x, adjoint_type), u0p)
+                @test Zygote.gradient(x -> f1(x, adjoint_type), u0p) ==
+                      Zygote.gradient(x -> f2(x, adjoint_type), u0p)
                 @test callback_count1 == callback_count2
             end
         end

--- a/test/prob_kwargs.jl
+++ b/test/prob_kwargs.jl
@@ -19,7 +19,7 @@ end
 
 function f2(a)
     _prob = remake(prob, p = [a[1]], saveat = savetimes)
-    predicted = solve(_prob, Tsit5(), sensealg = ForwardDiffSensitivity(), abstol = 1e-12,
+    predicted = solve(_prob, Tsit5(), sensealg = InterpolatingAdjoint(), abstol = 1e-12,
         reltol = 1e-12)
     sum(predicted.u[end])
 end
@@ -54,7 +54,10 @@ let callback_count1 = 0, callback_count2 = 0
 
     @testset "Callback duplication check" begin
         for adjoint_type in [
-            ForwardDiffSensitivity(), ReverseDiffAdjoint(), TrackerAdjoint()]
+            ForwardDiffSensitivity(), ReverseDiffAdjoint(), TrackerAdjoint(),
+            BacksolveAdjoint(), InterpolatingAdjoint(), QuadratureAdjoint()]
+            count1 = 0
+            count2 = 0
             u0p = [2.0, 3.0]
             Zygote.gradient(x -> f1(x, adjoint_type), u0p)
             Zygote.gradient(x -> f2(x, adjoint_type), u0p)

--- a/test/prob_kwargs.jl
+++ b/test/prob_kwargs.jl
@@ -53,16 +53,18 @@ let callback_count1 = 0, callback_count2 = 0
     end
 
     @testset "Callback duplication check" begin
+        u0p = [2.0, 3.0]
         for adjoint_type in [
             ForwardDiffSensitivity(), ReverseDiffAdjoint(), TrackerAdjoint(),
-            BacksolveAdjoint(), InterpolatingAdjoint(), QuadratureAdjoint()]
+            BacksolveAdjoint(), InterpolatingAdjoint(), QuadratureAdjoint(), GaussAdjoint()]
             count1 = 0
             count2 = 0
-            u0p = [2.0, 3.0]
-            Zygote.gradient(x -> f1(x, adjoint_type), u0p)
-            Zygote.gradient(x -> f2(x, adjoint_type), u0p)
-
-            @test callback_count1 == callback_count2
+            if adjoint_type == GaussAdjoint()
+                @test_broken Zygote.gradient(x -> f1(x, adjoint_type), u0p) == Zygote.gradient(x -> f2(x, adjoint_type), u0p)
+            else
+                @test Zygote.gradient(x -> f1(x, adjoint_type), u0p) == Zygote.gradient(x -> f2(x, adjoint_type), u0p)
+                @test callback_count1 == callback_count2
+            end
         end
     end
 end

--- a/test/prob_kwargs.jl
+++ b/test/prob_kwargs.jl
@@ -31,6 +31,7 @@ a = ones(3)
 @test Zygote.gradient(f, a)[1][3] == Zygote.gradient(f2, a)[1][3] == 0
 
 # callback in problem construction or in solve call should give same result
+# https://github.com/SciML/SciMLSensitivity.jl/issues/1081
 odef(du, u, p, t) = du .= u .* p
 prob = ODEProblem(odef, [2.0], (0.0, 1.0), [3.0])
 

--- a/test/prob_kwargs.jl
+++ b/test/prob_kwargs.jl
@@ -29,3 +29,29 @@ a = ones(3)
 @test Zygote.gradient(f, a)[1][1] ≈ Zygote.gradient(f2, a)[1][1]
 @test Zygote.gradient(f, a)[1][2] == Zygote.gradient(f2, a)[1][2] == 0
 @test Zygote.gradient(f, a)[1][3] == Zygote.gradient(f2, a)[1][3] == 0
+
+# callback in problem construction or in solve call should give same result
+odef(du, u, p, t) = du .= u .* p
+prob = ODEProblem(odef, [2.0], (0.0, 1.0), [3.0])
+
+function f1(u0p)
+    condition(u, t, integrator) = t == 0.5
+    affect!(integrator) = integrator.p[1] += 0.1
+    cb = DiscreteCallback(condition, affect!)
+    prob = ODEProblem{true}(odef, u0p[1:1], (0.0, 1.0), u0p[2:2]; callback = cb)
+    sum(solve(prob, Tsit5(), tstops = [0.5], sensealg = ForwardDiffSensitivity()))
+end
+
+function f2(u0p)
+    condition(u, t, integrator) = t == 0.5
+    affect!(integrator) = integrator.p[1] += 0.1
+    cb = DiscreteCallback(condition, affect!)
+    prob = ODEProblem{true}(odef, u0p[1:1], (0.0, 1.0), u0p[2:2])
+    sum(solve(
+        prob, Tsit5(), tstops = [0.5], callback = cb, sensealg = ForwardDiffSensitivity()))
+end
+u0p = [2.0, 3.0]
+
+@test f1(u0p) == f2(u0p)
+@test Zygote.gradient(f1, u0p)[1] == Zygote.gradient(f2, u0p)[1]
+


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context
Fixes https://github.com/SciML/SciMLSensitivity.jl/issues/1081

In some of the Adjoint methods, if a problem that was constructed with a callback is passed to it, the callback was being called twice. This because the `kwargs` argument already contains the callback that was passed to the problem constructor. So when the problem is solved, it uses the callback in the problem itself, and the callback passed to the `solve`, effectively doing the same callback operation twice. 

This PR just makes it so that only the callback in the `kwargs` is used. 
