### PR TITLE
chore: use tunables in vec_pjac

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -640,7 +640,7 @@ function DiffEqBase._concrete_solve_adjoint(
         du0 = reshape(du0, size(u0))
 
         dp = p === nothing || p === DiffEqBase.NullParameters() ? nothing :
-             dp isa AbstractArray ? reshape(dp', size(p)) : dp
+             dp isa AbstractArray ? reshape(dp', size(tunables)) : dp
 
         if originator isa SciMLBase.TrackerOriginator ||
            originator isa SciMLBase.ReverseDiffOriginator

--- a/src/gauss_adjoint.jl
+++ b/src/gauss_adjoint.jl
@@ -484,8 +484,8 @@ function vec_pjac!(out, λ, y, t, S::GaussIntegrand)
         ReverseDiff.reverse_pass!(tape)
         copyto!(vec(out), ReverseDiff.deriv(tp))
     elseif sensealg.autojacvec isa ZygoteVJP
-        _dy, back = Zygote.pullback(p) do p
-            vec(f(y, p, t))
+        _dy, back = Zygote.pullback(tunables) do tunables
+            vec(f(y, repack(tunables), t))
         end
         tmp = back(λ)
         if tmp[1] === nothing


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Allows reverse mode AD over MTKNNs. Last piece of https://github.com/SciML/ModelingToolkitNeuralNets.jl/issues/20 from SciMLSensitivity. 

Add any other context about the problem here.
