### PR TITLE
Interpolating Adjoint possible test fix

### DIFF
--- a/src/interpolating_adjoint.jl
+++ b/src/interpolating_adjoint.jl
@@ -174,6 +174,7 @@ function split_states(du, u, t, S::TS;
             interval = intervals[checkpoint_sol.cursor]
             if !(interval[1] <= t <= interval[2])
                 cursor′ = findcursor(intervals, t)
+                cursor′ = cursor′ > length(intervals) ? length(intervals) : cursor′
                 interval = intervals[cursor′]
                 cpsol_t = current_time(checkpoint_sol.cpsol)
                 if t isa ForwardDiff.Dual && eltype(S.y) <: AbstractFloat


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

I was getting some test failures in the adjoint tests when testing https://github.com/SciML/OrdinaryDiffEq.jl/pull/2567
https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/13182182796/job/36795499058?pr=2567

It looks like in one of the interpolating adjoint tests, the value of `t` was going slightly above the highest value of the last interval. This was causing `findcursor(intervals,t)` to return one higher than the length of intervals, so there would be an error when trying to use that as an index to `intervals`. This fixes the issue, but I'm not sure that it's the correct thing to do, given that probably `t` should never be higher than the highest value of the last interval in the first place. 

```julia
function split_states(du, u, t, S::TS;
        update = true) where {TS <:
                              ODEInterpolatingAdjointSensitivityFunction}
    (; sol, y, checkpoint_sol, discrete, prob, f) = S
    idx = length(y)
    if update
        if checkpoint_sol === nothing
            if t isa ForwardDiff.Dual && eltype(S.y) <: AbstractFloat
                y = sol(t, continuity = :right)
            else
                sol(y, t, continuity = :right)
            end
        else
            intervals = checkpoint_sol.intervals
            interval = intervals[checkpoint_sol.cursor]
            if !(interval[1] <= t <= interval[2])
                cursor′ = findcursor(intervals, t)
                cursor′ = cursor′ > length(intervals) ? length(intervals) : cursor′
                interval = intervals[cursor′]
                cpsol_t = current_time(checkpoint_sol.cpsol)
.............................................................................................................................................................................................................
```
