### PR TITLE
Correctly format signatures in docstrings

### DIFF
--- a/src/sensitivity_interface.jl
+++ b/src/sensitivity_interface.jl
@@ -492,9 +492,11 @@ function _adjoint_sensitivities(sol, sensealg::SteadyStateAdjoint, alg;
 end
 
 @doc doc"""
+```julia
 H = second_order_sensitivities(loss,prob,alg,args...;
                                sensealg=ForwardDiffOverAdjoint(InterpolatingAdjoint(autojacvec=ReverseDiffVJP())),
                                kwargs...)
+```
 
 Second order sensitivity analysis is used for the fast calculation of Hessian
 matrices.
@@ -547,9 +549,11 @@ function second_order_sensitivities(loss, prob, alg, args...;
 end
 
 @doc doc"""
+```julia
 Hv = second_order_sensitivity_product(loss,v,prob,alg,args...;
                                sensealg=ForwardDiffOverAdjoint(InterpolatingAdjoint(autojacvec=ReverseDiffVJP())),
                                kwargs...)
+```
 
 Second order sensitivity analysis product is used for the fast calculation of
 Hessian-vector products ``Hv`` without requiring the construction of the Hessian


### PR DESCRIPTION
## Checklist

- [X] Appropriate tests were added
- [X] Any code changes were done in a way that does not break public API
- [X] All documentation related to code changes were updated
- [X] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [X] Any new documentation only uses public API
  
## Additional context

The two docstrings [here](https://docs.sciml.ai/SciMLSensitivity/stable/manual/direct_adjoint_sensitivities/#SciMLSensitivity.second_order_sensitivities) and [here](https://docs.sciml.ai/SciMLSensitivity/stable/manual/direct_adjoint_sensitivities/#SciMLSensitivity.second_order_sensitivity_product) have incorrectly formatted signatures.  This PR just corrects them.