### PR TITLE
Take derivative at correct spot in `SteadyStateAdjoint`

### DIFF
--- a/src/steadystate_adjoint.jl
+++ b/src/steadystate_adjoint.jl
@@ -96,7 +96,7 @@ end
         nlprob = NonlinearProblem(nlfunc, vec(λ), p)
         operator = VecJacOperator(
             nlprob, vec(y), (λ); autodiff = get_autodiff_from_vjp(sensealg.autojacvec))
-        soperator = StatefulJacobianOperator(operator, vec(λ), p)
+        soperator = StatefulJacobianOperator(operator, vec(y), p)
         linear_problem = LinearProblem(soperator, vec(dgdu_val); u0 = vec(λ))
         solve(linear_problem, linsolve; alias = LinearAliasSpecifier(alias_A = true),
             sensealg.linsolve_kwargs...)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context
I noticed that we don't take the derivative in the correct spot in `SteadyStateAdjoint`, which causes issues with derivatives of large problems: fixes
https://github.com/SciML/SciMLSensitivity.jl/issues/1207

Essentially, we were taking the derivative of `f` at 0 always, since `lambda` comes from `zero(y)`, and the `StatefulJacobianOperator` was constructed with `lambda`. This meant that the adjoint equation was being set up incorrectly. 

Should probably add some tests for this too. 
