### PR TITLE
SteadyStateAdjoint fix for applying `dp` twice

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -1812,7 +1812,7 @@ function DiffEqBase._concrete_solve_adjoint(
 
         dp = adjoint_sensitivities(sol, alg; sensealg = sensealg, dgdu = df)
 
-        dp, Δtunables = if Δ isa AbstractArray || Δ isa Number
+        dp, Δtunables = if Δ isa AbstractArray || Δ isa Number 
             # if Δ isa AbstractArray, the gradients correspond to `u`
             # this is something that needs changing in the future, but
             # this is the applicable till the movement to structuaral
@@ -1828,10 +1828,15 @@ function DiffEqBase._concrete_solve_adjoint(
             end
         else
             dp, Δtunables = if isscimlstructure(p)
-                Δp = setproperties(dp, to_nt(Δ.prob.p))
-                Δtunables, _, _ = canonicalize(Tunable(), Δp)
-                dp, _, _ = canonicalize(Tunable(), dp)
-                dp, Δtunables
+                if (Δ.prob.p == ZeroTangent() || Δ.prob.p == NoTangent())
+                    dp, _, _ = canonicalize(Tunable(), dp)
+                    dp, nothing
+                else
+                    Δp = setproperties(dp, to_nt(Δ.prob.p))
+                    Δtunables, _, _ = canonicalize(Tunable(), Δp)
+                    dp, _, _ = canonicalize(Tunable(), dp)
+                    dp, Δtunables
+                end
             elseif isfunctor(p)
                 dp, _ = Functors.functor(dp)
                 Δtunables, _ = Functors.functor(Δ.prob.p)

--- a/test/steady_state.jl
+++ b/test/steady_state.jl
@@ -473,6 +473,8 @@ end
 
     dp10 = Zygote.gradient(p -> test_loss2(p, prob5, Broyden()), p)[1]
     dp11 = Zygote.gradient(p -> test_loss2(p, prob6, Broyden()), p)[1]
+    dp12 = ForwardDiff.gradient(p -> test_loss2(p, prob6, Broyden()), p)
+ 
 
     @test dp1≈dp2 rtol=1e-10
     @test dp1≈dp3 rtol=1e-10
@@ -482,7 +484,9 @@ end
     @test dp1≈dp7 rtol=1e-10
     @test dp1≈dp8 rtol=1e-10
     @test dp1≈dp9 rtol=1e-10
-    @test dp10≈dp11 rtol=1e-5
+    @test dp10≈dp11 rtol=1e-10
+    @test dp11≈dp12 rtol=1e-10
+    @test dp10≈dp12 rtol=1e-10
 
     # Larger Batched Problem: For testing the Iterative Solvers Path
     u0 = zeros(128)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Fixes https://github.com/SciML/SciMLSensitivity.jl/issues/1210 ? 
