### PR TITLE
Fix Mooncake ArrayPartition solve cotangents

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -21,6 +21,18 @@ const ConcreteNonlinearProblem = Union{
 const have_not_warned_vjp = Ref(true)
 const STACKTRACE_WITH_VJPWARN = Ref(false)
 
+function _materialize_arraypartition_tangent(tangent::Tangent, primal::ArrayPartition)
+    components = tangent.x
+    length(components) == length(primal.x) ||
+        throw(DimensionMismatch("cotangent and primal ArrayPartitions have different lengths"))
+
+    values = ntuple(length(primal.x)) do i
+        component = unthunk(components[i])
+        return component isa Union{NoTangent, ZeroTangent} ? zero(primal.x[i]) : component
+    end
+    return ArrayPartition(values...)
+end
+
 
 # Non-capturing probe for the EnzymeVJP availability check. The RHS `f` is passed as an
 # explicit argument (annotated `Duplicated`) rather than captured in a closure. Capturing it
@@ -883,6 +895,9 @@ function SciMLBase._concrete_solve_adjoint(
                         Δ isa Tangent
                     x = Δ isa AbstractVectorOfArray ? Δu.u[i] :
                         (Δ isa Tangent ? Δu[i] : Δ[i])
+                    if x isa Tangent && u isa ArrayPartition
+                        x = _materialize_arraypartition_tangent(x, u)
+                    end
                     if _save_idxs isa Number
                         _out[_save_idxs] = x[_save_idxs]
                     elseif _save_idxs isa Colon
@@ -962,8 +977,13 @@ function SciMLBase._concrete_solve_adjoint(
             else
                 !Base.isconcretetype(eltype(Δ)) &&
                     ((Δ isa AbstractVectorOfArray ? Δ.u[i] : Δ[i]) isa NoTangent || eltype(Δ) <: NoTangent) && return
-                if Δ isa AbstractArray{<:AbstractArray} || Δ isa AbstractVectorOfArray
-                    x = Δ isa AbstractVectorOfArray ? Δ.u[i] : Δ[i]
+                if Δ isa AbstractArray{<:AbstractArray} || Δ isa AbstractVectorOfArray ||
+                        Δ isa Tangent
+                    x = Δ isa AbstractVectorOfArray ? Δ.u[i] :
+                        (Δ isa Tangent ? Δ.u[i] : Δ[i])
+                    if x isa Tangent && u isa ArrayPartition
+                        x = _materialize_arraypartition_tangent(x, u)
+                    end
                     if _save_idxs isa Number
                         _out = @view(x[_save_idxs])
                     elseif _save_idxs isa Colon
@@ -1052,7 +1072,13 @@ function SciMLBase._concrete_solve_adjoint(
             )
         end
 
-        du0 = reshape(du0, size(u0))
+        if u0 isa ArrayPartition
+            du0_partition = zero(u0)
+            copyto!(du0_partition, du0)
+            du0 = du0_partition
+        else
+            du0 = reshape(du0, size(u0))
+        end
 
         dp_full = if p === nothing || p === SciMLBase.NullParameters()
             nothing

--- a/test/Core6/second_order_odes.jl
+++ b/test/Core6/second_order_odes.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEq, SciMLSensitivity, Zygote, RecursiveArrayTools, Test
+import Mooncake
 
 u0 = Float32[1.0; 2.0]
 du0 = Float32[0.0; 2.0]
@@ -80,3 +81,21 @@ ddu04, du04, dp4 = Zygote.gradient(
 @test dp1 ≈ dp2
 @test dp1 ≈ dp3
 @test dp1 ≈ dp4
+
+@testset "Mooncake ArrayPartition cotangent" begin
+    loss(p) = sum(
+        Array(
+            solve(
+                prob, Tsit5(); p, saveat = t,
+                sensealg = InterpolatingAdjoint(autojacvec = EnzymeVJP())
+            )
+        )
+    )
+    cache = Mooncake.prepare_gradient_cache(
+        loss, p; config = Mooncake.Config(; friendly_tangents = true)
+    )
+    value, gradient = Mooncake.value_and_gradient!!(cache, loss, p)
+
+    @test value ≈ loss(p)
+    @test gradient[2] ≈ dp1
+end


### PR DESCRIPTION
## Summary

- materialize nested Mooncake/ChainRules `Tangent` values into `ArrayPartition` cotangents before the adjoint callback uses array operations
- preserve the `ArrayPartition` structure of the initial-state cotangent returned from the solve rule
- add a direct Mooncake-over-`SecondOrderODEProblem` regression test

## Root cause

The switch of `second_order_neural.md` to `AutoMooncake` in `7c1d5ba` depended on the cotangent handling proposed in #1422, but that PR was closed without merging. Mooncake returns the state cotangent as nested `Tangent.x` components. The adjoint callback passed that structure directly to `vec`, causing `MethodError: vec(::ChainRulesCore.Tangent...)`. After materialization, flattening `du0` with `reshape` also violated RecursiveArrayTools' expected `ArrayPartition` tangent structure.

This change handles the known structure strictly: incompatible component counts throw instead of silently producing a zero gradient.

## Validation

- reduced Mooncake gradient reproduction: exit 0, value `77.58855f0`, parameter gradient `Float32[-11.3909645, -31.066608]`
- `GROUP=Core6 julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`: 155 passed, 4 pre-existing broken, 159 total; package tests passed
- isolated `second_order_neural.md` Documenter build: exit 0 through HTML rendering
- Runic check on both changed Julia files passed
- `git diff --check` passed

Ignore this PR until it has been reviewed by @ChrisRackauckas.
