### PR TITLE
native `MooncakeAdjoint` `solve_up` rule + explicit HVP errors for other `sensealgs`

### DIFF
--- a/ext/SciMLSensitivityMooncakeExt.jl
+++ b/ext/SciMLSensitivityMooncakeExt.jl
@@ -2,11 +2,13 @@ module SciMLSensitivityMooncakeExt
 
 using SciMLSensitivity: SciMLSensitivity, FakeIntegrator
 using Mooncake: Mooncake
+import Mooncake: MinimalCtx, ForwardMode, Dual, CoDual, frule!!, rrule!!, @is_primitive,
+    @zero_derivative
 import SciMLSensitivity: get_paramjac_config, get_cb_paramjac_config, mooncake_run_ad,
     MooncakeVJP, MooncakeLoaded,
     DiffEqBase, MooncakeAdjoint, _init_originator_gradient,
     ReverseDiffAdjoint, TrackerAdjoint, ForwardSensitivity,
-    EnzymeAdjoint
+    EnzymeAdjoint, ZygoteAdjoint
 using SciMLSensitivity: SciMLBase, SciMLStructures, canonicalize, Tunable, isscimlstructure,
     SciMLStructuresCompatibilityError, convert_tspan,
     has_continuous_callback,
@@ -15,6 +17,26 @@ using SciMLSensitivity: FunctionWrappersWrappers, ODEFunction
 using SciMLBase: remake, solve
 using ChainRulesCore: NoTangent, ZeroTangent, Tangent, unthunk
 using Accessors: @reset
+
+# Mirrors `Mooncake.__call_rule` (src/utils.jl) instead of depending on it directly: that's
+# a double-underscore internal helper, not part of Mooncake's rule-writing API. On Julia
+# >= 1.11 it's just `rule(args...)`; on 1.10 it routes through `Base.inferencebarrier` and
+# a `@noinline` erased call to dodge a real compiler invalidation bug (see Mooncake's own
+# comment for the MWE). SciMLSensitivity still supports 1.10, so this keeps the workaround
+# instead of silently dropping it.
+@static if VERSION < v"1.11-"
+    @noinline _call_built_rule_erased(rule, args) = rule(args...)
+    @inline _call_built_rule(rule, args) = _call_built_rule_erased(Base.inferencebarrier(rule), args)
+else
+    @inline _call_built_rule(rule, args) = rule(args...)
+end
+
+# `automatic_sensealg_choice` is a discrete algorithm choice, never a differentiable
+# function of u0/p, but its body has a try/catch Mooncake's forward-mode compiler can't
+# trace. Zero-derivative keeps Mooncake from ever looking inside.
+@zero_derivative(
+    MinimalCtx, Tuple{typeof(SciMLSensitivity.automatic_sensealg_choice),Vararg},
+)
 
 # Mooncake-native gradient for the DAE/ODE init path. Avoids pulling Zygote
 # into the rrule when the user is differentiating with Mooncake. The default
@@ -191,21 +213,19 @@ function SciMLBase._concrete_solve_adjoint(
         return sol
     end
 
-    # `_concrete_solve_adjoint` must return `(primal, pullback)` where `pullback` is called
-    # *later*, with a seed that isn't known yet -- so the Mooncake gradient can't be computed
-    # eagerly in one call. Mooncake's public `value_and_pullback!!` only offers an eager,
-    # single-call form (build the rule, run forward, and immediately apply the seed all at
-    # once), so we split its two halves by hand: build the rule and run the forward pass now
-    # (mirroring `Mooncake.__value_and_pullback!!`'s first half), and defer applying the seed
-    # to `pb!!` until `mooncake_adjoint_backpass` is actually invoked.
+    # `_concrete_solve_adjoint` must return `(primal, pullback)`, with the seed for `pullback`
+    # not known until later -- but Mooncake's public `value_and_pullback!!` only offers an
+    # eager, single-call form (build + run forward + apply seed, all at once). So we split it
+    # by hand: build the rule and run the forward pass now, and defer applying the seed until
+    # `mooncake_adjoint_backpass` is actually invoked.
     rule = Mooncake.build_rrule(mooncake_adjoint_forwardpass, u0, tunables)
     fx = (
-        Mooncake.CoDual(mooncake_adjoint_forwardpass, Mooncake.zero_tangent(mooncake_adjoint_forwardpass)),
-        Mooncake.CoDual(u0, Mooncake.zero_tangent(u0)),
-        Mooncake.CoDual(tunables, Mooncake.zero_tangent(tunables)),
+        CoDual(mooncake_adjoint_forwardpass, Mooncake.zero_tangent(mooncake_adjoint_forwardpass)),
+        CoDual(u0, Mooncake.zero_tangent(u0)),
+        CoDual(tunables, Mooncake.zero_tangent(tunables)),
     )
     fx_fwds = Mooncake.tuple_map(Mooncake.to_fwds, fx)
-    out, pb!! = Mooncake.__call_rule(rule, fx_fwds)
+    out, pb!! = _call_built_rule(rule, fx_fwds)
 
     function mooncake_adjoint_backpass(ybar)
         # Convert the incoming ChainRules-style cotangent into the Mooncake tangent type of
@@ -244,25 +264,15 @@ end
 # ============================================================================
 # Mooncake-native `solve_up` rule for `MooncakeAdjoint`
 #
-# The `_concrete_solve_adjoint(..., ::MooncakeAdjoint, ...)` method above conforms to the
-# ChainRulesCore.rrule contract, which forces Mooncake's generic `@from_rrule`-based
-# `solve_up` primitive (`DiffEqBaseMooncakeExt.jl`) to round-trip the output cotangent
-# through `mooncake_tangent`/`to_cr_tangent`. `mooncake_tangent` only has methods for
-# simple array/scalar/tuple primals (see AGENTS.md's restriction on `@from_rrule`/
-# `@from_chainrules`), so it has no case for a struct as deeply nested as `ODESolution`,
-# and that conversion throws `ArgumentError: ... does not currently have a method of
-# mooncake_tangent`.
-#
-# `MooncakeAdjoint`'s own gradient computation never leaves Mooncake's native
-# representation in the first place, so there's no need to go anywhere near ChainRules
-# here at all. This is a direct `Mooncake.rrule!!` for `solve_up` restricted to
-# `sensealg::MooncakeAdjoint`, mirroring the `_MooncakeOverAnotherADSensealg` pattern
-# below, but computing the adjoint via a *nested* Mooncake `build_rrule` call instead of
-# delegating to a foreign-AD-backed ChainRules pullback -- so the whole round trip stays
-# in native fdata/rdata. The nested call reuses the incoming `u0`/`p` CoDuals' fdata
-# directly (rather than allocating fresh tangents), so in-place fdata accumulation still
-# lands in the same, potentially-aliased buffers the surrounding reverse pass expects
-# (see the "Aliasing Invariant" in docs/src/understanding_mooncake/rule_system.md).
+# The generic `@from_rrule`-based `solve_up` primitive (`DiffEqBaseMooncakeExt.jl`) round-trips
+# through `mooncake_tangent`/`to_cr_tangent`, which has no case for a struct as deeply nested
+# as `ODESolution` and throws `ArgumentError: ... does not currently have a method of
+# mooncake_tangent`. `MooncakeAdjoint`'s gradient never needs to leave Mooncake's native
+# representation, so this rule bypasses ChainRules entirely: a *nested* `Mooncake.build_rrule`
+# call (not a foreign-AD-backed pullback like `_MooncakeOverAnotherADSensealg` below), reusing
+# the incoming `u0`/`p` CoDuals' fdata directly so in-place accumulation lands in the same,
+# potentially-aliased buffers the surrounding reverse pass expects (see the "Aliasing
+# Invariant" in docs/src/understanding_mooncake/rule_system.md).
 function _solve_up_mooncake_native_forwardpass(prob, alg_and_rest, kwargs, _u0, _p)
     _prob = remake(prob; u0 = _u0, p = _p)
     sol = solve(
@@ -272,17 +282,17 @@ function _solve_up_mooncake_native_forwardpass(prob, alg_and_rest, kwargs, _u0, 
 end
 
 function _solve_up_mooncake_native(
-        prob, sensealg, u0::Mooncake.CoDual, p::Mooncake.CoDual, alg_and_rest...; kwargs...
+        prob, sensealg, u0::CoDual, p::CoDual, alg_and_rest...; kwargs...
     )
     forwardpass(_u0, _p) = _solve_up_mooncake_native_forwardpass(
         prob, alg_and_rest, kwargs, _u0, _p
     )
     rule = Mooncake.build_rrule(forwardpass, Mooncake.primal(u0), Mooncake.primal(p))
     fx_fwds = (
-        Mooncake.CoDual(forwardpass, Mooncake.fdata(Mooncake.zero_tangent(forwardpass))),
+        CoDual(forwardpass, Mooncake.fdata(Mooncake.zero_tangent(forwardpass))),
         u0, p,
     )
-    out, pb!! = Mooncake.__call_rule(rule, fx_fwds)
+    out, pb!! = _call_built_rule(rule, fx_fwds)
     function native_pb!!(y_rdata)
         _, u0_rdata, p_rdata = pb!!(y_rdata)
         return u0_rdata, p_rdata
@@ -290,11 +300,11 @@ function _solve_up_mooncake_native(
     return Mooncake.primal(out), Mooncake.tangent(out), native_pb!!
 end
 
-function Mooncake.rrule!!(
-        f::Mooncake.CoDual{typeof(DiffEqBase.solve_up)},
-        prob::Mooncake.CoDual{<:DiffEqBase.AbstractDEProblem},
-        sensealg::Mooncake.CoDual{<:MooncakeAdjoint},
-        u0::Mooncake.CoDual, p::Mooncake.CoDual, alg_and_rest::Mooncake.CoDual...,
+function rrule!!(
+        f::CoDual{typeof(DiffEqBase.solve_up)},
+        prob::CoDual{<:DiffEqBase.AbstractDEProblem},
+        sensealg::CoDual{<:MooncakeAdjoint},
+        u0::CoDual, p::CoDual, alg_and_rest::CoDual...,
     )
     fargs = (f, prob, sensealg, u0, p, alg_and_rest...)
     primals = Mooncake.tuple_map(Mooncake.primal, fargs)
@@ -315,16 +325,16 @@ function Mooncake.rrule!!(
         )
     end
 
-    return Mooncake.CoDual(y_primal, y_fdata), pb!!
+    return CoDual(y_primal, y_fdata), pb!!
 end
 
-function Mooncake.rrule!!(
-        ::Mooncake.CoDual{typeof(Core.kwcall)},
-        kwargs::Mooncake.CoDual{<:NamedTuple},
-        f::Mooncake.CoDual{typeof(DiffEqBase.solve_up)},
-        prob::Mooncake.CoDual{<:DiffEqBase.AbstractDEProblem},
-        sensealg::Mooncake.CoDual{<:MooncakeAdjoint},
-        u0::Mooncake.CoDual, p::Mooncake.CoDual, alg_and_rest::Mooncake.CoDual...,
+function rrule!!(
+        ::CoDual{typeof(Core.kwcall)},
+        kwargs::CoDual{<:NamedTuple},
+        f::CoDual{typeof(DiffEqBase.solve_up)},
+        prob::CoDual{<:DiffEqBase.AbstractDEProblem},
+        sensealg::CoDual{<:MooncakeAdjoint},
+        u0::CoDual, p::CoDual, alg_and_rest::CoDual...,
     )
     fargs = (f, prob, sensealg, u0, p, alg_and_rest...)
     primals = Mooncake.tuple_map(Mooncake.primal, fargs)
@@ -348,26 +358,23 @@ function Mooncake.rrule!!(
         return Mooncake.NoRData(), kwargs_rdata, args_rdata...
     end
 
-    return Mooncake.CoDual(y_primal, y_fdata), pb!!
+    return CoDual(y_primal, y_fdata), pb!!
 end
 
 # Mooncake stacked over ReverseDiffAdjoint/TrackerAdjoint/ForwardSensitivity
-# (SciML/SciMLSensitivity.jl#1510, chalk-lab/Mooncake.jl#1208). `solve`
-# reports which AD is active via `set_mooncakeoriginator_if_mooncake`, a
-# `@mooncake_overlay` meant to swap in `MooncakeOriginator()`. That never
-# fires here: `ChainRulesOriginator`/`MooncakeOriginator` are zero-field
-# structs, which Julia's compiler treats as compile-time constants regardless
-# of runtime provenance, so the whole overlaid call gets folded away before
-# any rule dispatch happens. These hand-written `solve_up` rules sidestep
-# detection entirely -- they only ever run under Mooncake, so they construct
-# `MooncakeOriginator()` directly and dispatch into the existing
-# `MooncakeOriginator` methods added in #1420 (src/concrete_solve.jl), which
-# re-solve with a plain `Float64` primal Mooncake can build a `CoDual` for.
-# Being more specific than the generic rule's `Union{Nothing,
-# AbstractSensitivityAlgorithm}` signature, dispatch prefers these three
-# sensealgs and falls back to the generic rule for everything else.
+# (SciML/SciMLSensitivity.jl#1510, chalk-lab/Mooncake.jl#1208).
+#
+# These sensealgs need to know which AD is driving them (`originator`), normally
+# auto-detected via a `@mooncake_overlay`. That detection never fires under Mooncake:
+# `MooncakeOriginator`/`ChainRulesOriginator` are zero-field structs, which Julia constant-
+# folds away before any rule dispatch happens. So these rules skip detection and construct
+# `MooncakeOriginator()` directly, dispatching into the existing `MooncakeOriginator`
+# methods (#1420, src/concrete_solve.jl) that re-solve with a plain primal Mooncake can wrap
+# in a `CoDual`. More specific than the generic rule's `Union{Nothing,
+# AbstractSensitivityAlgorithm}` signature, so dispatch prefers these three sensealgs and
+# falls back to the generic rule for everything else.
 const _MooncakeOverAnotherADSensealg = Union{
-    ReverseDiffAdjoint, TrackerAdjoint, ForwardSensitivity, EnzymeAdjoint,
+    ReverseDiffAdjoint, TrackerAdjoint, ForwardSensitivity,
 }
 
 function _solve_up_mooncake_over_another_ad(prob, sensealg, u0, p, alg_and_kwargs...; kwargs...)
@@ -376,13 +383,11 @@ function _solve_up_mooncake_over_another_ad(prob, sensealg, u0, p, alg_and_kwarg
     )
 end
 
-# `cr_dfargs` is shaped like `_concrete_solve_adjoint`'s own arg list
-# (`prob̄, alḡ, sensealḡ, ū0, p̄, originator̄, tail̄...`), not `solve_up`'s --
-# `_solve_adjoint` takes the same no-tail branch whether `alg` arrived
-# explicitly or was extracted from kwargs, so `alg_and_rest` can be empty here
-# even though `_concrete_solve_adjoint` always has an `alg` slot. Reorder/pad
-# to `fargs = (f, prob, sensealg, u0, p, alg_and_rest...)`, dropping
-# `originator` (a zero-field marker, never differentiable).
+# `cr_dfargs` is shaped like `_concrete_solve_adjoint`'s arg list
+# (`prob̄, alḡ, sensealḡ, ū0, p̄, originator̄, tail̄...`), not `solve_up`'s. Reorders/pads it to
+# `fargs = (f, prob, sensealg, u0, p, alg_and_rest...)`, dropping `originator` (a zero-field
+# marker, never differentiable). `alg_and_rest` can be empty even though `_concrete_solve_adjoint`
+# always has an `alg` slot -- `_solve_adjoint` takes the same no-tail branch either way.
 function _match_fargs_cotangents(cr_dfargs, alg_and_rest)
     alg_and_rest_cotangents = isempty(alg_and_rest) ? () : (cr_dfargs[2], cr_dfargs[7:end]...)
     return (
@@ -391,13 +396,12 @@ function _match_fargs_cotangents(cr_dfargs, alg_and_rest)
     )
 end
 
-function Mooncake.rrule!!(
-        f::Mooncake.CoDual{typeof(DiffEqBase.solve_up)},
-        prob::Mooncake.CoDual{<:SciMLBase.AbstractDEProblem},
-        sensealg::Mooncake.CoDual{<:_MooncakeOverAnotherADSensealg},
-        u0::Mooncake.CoDual, p::Mooncake.CoDual, alg_and_rest::Mooncake.CoDual...,
+function rrule!!(
+        f::CoDual{typeof(DiffEqBase.solve_up)},
+        prob::CoDual{<:SciMLBase.AbstractDEProblem},
+        sensealg::CoDual{<:_MooncakeOverAnotherADSensealg},
+        u0::CoDual, p::CoDual, alg_and_rest::CoDual...,
     )
-    sensealg isa EnzymeAdjoint && error("EnzymeAdjoint currently is not supported inside of Mooncake autodiff")
     fargs = (f, prob, sensealg, u0, p, alg_and_rest...)
     primals = Mooncake.tuple_map(Mooncake.primal, fargs)
     lazy_rdata = Mooncake.tuple_map(Mooncake.lazy_zero_rdata, primals)
@@ -414,16 +418,16 @@ function Mooncake.rrule!!(
         end
     end
 
-    return Mooncake.CoDual(y_primal, y_fdata), pb!!
+    return CoDual(y_primal, y_fdata), pb!!
 end
 
-function Mooncake.rrule!!(
-        ::Mooncake.CoDual{typeof(Core.kwcall)},
-        kwargs::Mooncake.CoDual{<:NamedTuple},
-        f::Mooncake.CoDual{typeof(DiffEqBase.solve_up)},
-        prob::Mooncake.CoDual{<:SciMLBase.AbstractDEProblem},
-        sensealg::Mooncake.CoDual{<:_MooncakeOverAnotherADSensealg},
-        u0::Mooncake.CoDual, p::Mooncake.CoDual, alg_and_rest::Mooncake.CoDual...,
+function rrule!!(
+        ::CoDual{typeof(Core.kwcall)},
+        kwargs::CoDual{<:NamedTuple},
+        f::CoDual{typeof(DiffEqBase.solve_up)},
+        prob::CoDual{<:SciMLBase.AbstractDEProblem},
+        sensealg::CoDual{<:_MooncakeOverAnotherADSensealg},
+        u0::CoDual, p::CoDual, alg_and_rest::CoDual...,
     )
     fargs = (f, prob, sensealg, u0, p, alg_and_rest...)
     primals = Mooncake.tuple_map(Mooncake.primal, fargs)
@@ -447,7 +451,162 @@ function Mooncake.rrule!!(
         return Mooncake.NoRData(), kwargs_rdata, args_rdata...
     end
 
-    return Mooncake.CoDual(y_primal, y_fdata), pb!!
+    return CoDual(y_primal, y_fdata), pb!!
+end
+
+# `EnzymeAdjoint`/`ZygoteAdjoint` under Mooncake: confirmed broken by direct testing, for
+# two different reasons. `ZygoteAdjoint` fails inside Zygote's own tracing of solve()'s
+# internals (a mutating-array operation Zygote can't differentiate, unrelated to Mooncake).
+# `EnzymeAdjoint` fails on a type mismatch inside Mooncake's own rule machinery. Neither
+# currently reaches this extension at all -- both fall through to the generic
+# `@from_rrule`-based solve_up primitive and crash with a confusing, deep stacktrace.
+# Erroring here instead, before any of that runs, gives a clear message up front.
+const _MooncakeUnsupportedAnotherADSensealg = Union{EnzymeAdjoint, ZygoteAdjoint}
+
+function _mooncake_another_ad_backend_unsupported(sensealg)
+    error(
+        "solve() with $(typeof(sensealg)) is not currently supported under Mooncake " *
+            "(confirmed broken by direct testing -- not just untested). Use " *
+            "MooncakeAdjoint() instead."
+    )
+end
+
+function rrule!!(
+        ::CoDual{typeof(DiffEqBase.solve_up)},
+        ::CoDual{<:DiffEqBase.AbstractDEProblem},
+        sensealg::CoDual{<:_MooncakeUnsupportedAnotherADSensealg},
+        ::CoDual, ::CoDual, ::CoDual...,
+    )
+    _mooncake_another_ad_backend_unsupported(Mooncake.primal(sensealg))
+end
+
+function rrule!!(
+        ::CoDual{typeof(Core.kwcall)},
+        ::CoDual{<:NamedTuple},
+        ::CoDual{typeof(DiffEqBase.solve_up)},
+        ::CoDual{<:DiffEqBase.AbstractDEProblem},
+        sensealg::CoDual{<:_MooncakeUnsupportedAnotherADSensealg},
+        ::CoDual, ::CoDual, ::CoDual...,
+    )
+    _mooncake_another_ad_backend_unsupported(Mooncake.primal(sensealg))
+end
+
+# Forward-mode primitive for `DiffEqBase._solve_adjoint` under ReverseDiffAdjoint and
+# TrackerAdjoint (SciML/SciMLSensitivity.jl#1427) -- just an explicit error, see the
+# message below for why. Registered on `_solve_adjoint` rather than `solve_up`, since the
+# rrule above calls `_solve_adjoint` directly and `solve_up` is never reached on this
+# path. Deliberately narrower than `_MooncakeOverAnotherADSensealg` (excludes
+# ForwardSensitivity, which gets its own error below for a different reason).
+const _MooncakeDelegatesToAnotherAD = Union{ReverseDiffAdjoint, TrackerAdjoint}
+
+function _mooncake_solve_adjoint_forward_mode_unsupported(sensealg)
+    error(
+        "value_and_hvp!! can't compute a Hessian-vector product for solve() with " *
+            "$(typeof(sensealg)) under Mooncake. $(typeof(sensealg)) gets its gradient by " *
+            "calling ReverseDiff.jl or Tracker.jl, and Mooncake can't safely forward-mode " *
+            "differentiate through another AD package's internals " *
+            "(SciML/SciMLSensitivity.jl#1427). Use MooncakeAdjoint() if you need an HVP " *
+            "today. A real fix means writing a Mooncake-native adjoint rule for " *
+            "$(typeof(sensealg)) (a continuous adjoint method using only " *
+            "Mooncake.value_and_gradient!!/value_and_hvp!! on the ODE right-hand side), so " *
+            "Mooncake's forward-over-reverse machinery can differentiate it the way it " *
+            "already does for MooncakeAdjoint."
+    )
+end
+
+@is_primitive(
+    MinimalCtx, ForwardMode,
+    Tuple{
+        typeof(DiffEqBase._solve_adjoint), SciMLBase.AbstractDEProblem,
+        _MooncakeDelegatesToAnotherAD, Any, Any, SciMLBase.MooncakeOriginator, Vararg,
+    },
+)
+function frule!!(
+        ::Dual{typeof(DiffEqBase._solve_adjoint)},
+        ::Dual{<:SciMLBase.AbstractDEProblem},
+        sensealg::Dual{<:_MooncakeDelegatesToAnotherAD},
+        ::Dual, ::Dual,
+        ::Dual{<:SciMLBase.MooncakeOriginator},
+        ::Dual...,
+    )
+    _mooncake_solve_adjoint_forward_mode_unsupported(Mooncake.primal(sensealg))
+end
+
+@is_primitive(
+    MinimalCtx, ForwardMode,
+    Tuple{
+        typeof(Core.kwcall), NamedTuple, typeof(DiffEqBase._solve_adjoint),
+        SciMLBase.AbstractDEProblem, _MooncakeDelegatesToAnotherAD, Any, Any,
+        SciMLBase.MooncakeOriginator, Vararg,
+    },
+)
+function frule!!(
+        ::Dual{typeof(Core.kwcall)},
+        ::Dual{<:NamedTuple},
+        ::Dual{typeof(DiffEqBase._solve_adjoint)},
+        ::Dual{<:SciMLBase.AbstractDEProblem},
+        sensealg::Dual{<:_MooncakeDelegatesToAnotherAD},
+        ::Dual, ::Dual,
+        ::Dual{<:SciMLBase.MooncakeOriginator},
+        ::Dual...,
+    )
+    _mooncake_solve_adjoint_forward_mode_unsupported(Mooncake.primal(sensealg))
+end
+
+# ForwardSensitivity's HVP is also unsupported, but not for the ReverseDiff/Tracker
+# reason above -- it doesn't delegate to another AD package at all. Plain Mooncake
+# tracing here hits a missing rule for FunctionWrapper's .obj access first, and past
+# that, a deeper wall: tracing into ForwardSensitivity's own ForwardDiff.jl Jacobian
+# machinery inside solve_call hits the same type-prediction mismatch as
+# chalk-lab/Mooncake.jl#1209.
+function _mooncake_forward_sensitivity_hvp_unsupported()
+    error(
+        "value_and_hvp!! can't compute a Hessian-vector product for solve() with " *
+            "ForwardSensitivity() under Mooncake. ForwardSensitivity computes its " *
+            "gradient using ForwardDiff.jl internally, and forward-mode-differentiating " *
+            "that with Mooncake hits a type-prediction mismatch deep in solve_call " *
+            "(the same class of issue as chalk-lab/Mooncake.jl#1209). Use MooncakeAdjoint() " *
+            "if you need an HVP today. See SciML/SciMLSensitivity.jl#1427 for what was tried."
+    )
+end
+
+@is_primitive(
+    MinimalCtx, ForwardMode,
+    Tuple{
+        typeof(DiffEqBase._solve_adjoint), SciMLBase.AbstractDEProblem,
+        ForwardSensitivity, Any, Any, SciMLBase.MooncakeOriginator, Vararg,
+    },
+)
+function frule!!(
+        ::Dual{typeof(DiffEqBase._solve_adjoint)},
+        ::Dual{<:SciMLBase.AbstractDEProblem},
+        ::Dual{<:ForwardSensitivity},
+        ::Dual, ::Dual,
+        ::Dual{<:SciMLBase.MooncakeOriginator},
+        ::Dual...,
+    )
+    _mooncake_forward_sensitivity_hvp_unsupported()
+end
+
+@is_primitive(
+    MinimalCtx, ForwardMode,
+    Tuple{
+        typeof(Core.kwcall), NamedTuple, typeof(DiffEqBase._solve_adjoint),
+        SciMLBase.AbstractDEProblem, ForwardSensitivity, Any, Any,
+        SciMLBase.MooncakeOriginator, Vararg,
+    },
+)
+function frule!!(
+        ::Dual{typeof(Core.kwcall)},
+        ::Dual{<:NamedTuple},
+        ::Dual{typeof(DiffEqBase._solve_adjoint)},
+        ::Dual{<:SciMLBase.AbstractDEProblem},
+        ::Dual{<:ForwardSensitivity},
+        ::Dual, ::Dual,
+        ::Dual{<:SciMLBase.MooncakeOriginator},
+        ::Dual...,
+    )
+    _mooncake_forward_sensitivity_hvp_unsupported()
 end
 
 end

--- a/ext/SciMLSensitivityMooncakeExt.jl
+++ b/ext/SciMLSensitivityMooncakeExt.jl
@@ -12,6 +12,7 @@ using SciMLSensitivity: SciMLBase, SciMLStructures, canonicalize, Tunable, issci
     has_continuous_callback,
     unwrapped_f, state_values, current_time
 using SciMLSensitivity: FunctionWrappersWrappers, ODEFunction
+using SciMLBase: remake, solve
 using ChainRulesCore: NoTangent, ZeroTangent, Tangent, unthunk
 using Accessors: @reset
 
@@ -166,7 +167,7 @@ function SciMLBase._concrete_solve_adjoint(
                     prob.f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper ||
                         SciMLBase.specialization(prob.f) === SciMLBase.AutoSpecialize
                 )
-                f = ODEFunction{isinplace(prob), SciMLBase.FullSpecialize}(unwrapped_f(prob.f))
+                f = ODEFunction{DiffEqBase.isinplace(prob), SciMLBase.FullSpecialize}(unwrapped_f(prob.f))
                 _prob = remake(
                     prob, f = f, u0 = _u0, p = _p, tspan = _tspan, callback = nothing
                 )
@@ -190,36 +191,34 @@ function SciMLBase._concrete_solve_adjoint(
         return sol
     end
 
-    out,
-        pullback = Mooncake.value_and_pullback!!(
-        Mooncake.CoDual(mooncake_adjoint_forwardpass, Mooncake.NoFData()),
-        Mooncake.CoDual(u0, Mooncake.zero_rdata(u0)),
-        Mooncake.CoDual(tunables, Mooncake.zero_rdata(tunables))
+    # `_concrete_solve_adjoint` must return `(primal, pullback)` where `pullback` is called
+    # *later*, with a seed that isn't known yet -- so the Mooncake gradient can't be computed
+    # eagerly in one call. Mooncake's public `value_and_pullback!!` only offers an eager,
+    # single-call form (build the rule, run forward, and immediately apply the seed all at
+    # once), so we split its two halves by hand: build the rule and run the forward pass now
+    # (mirroring `Mooncake.__value_and_pullback!!`'s first half), and defer applying the seed
+    # to `pb!!` until `mooncake_adjoint_backpass` is actually invoked.
+    rule = Mooncake.build_rrule(mooncake_adjoint_forwardpass, u0, tunables)
+    fx = (
+        Mooncake.CoDual(mooncake_adjoint_forwardpass, Mooncake.zero_tangent(mooncake_adjoint_forwardpass)),
+        Mooncake.CoDual(u0, Mooncake.zero_tangent(u0)),
+        Mooncake.CoDual(tunables, Mooncake.zero_tangent(tunables)),
     )
+    fx_fwds = Mooncake.tuple_map(Mooncake.to_fwds, fx)
+    out, pb!! = Mooncake.__call_rule(rule, fx_fwds)
 
     function mooncake_adjoint_backpass(ybar)
-        tmp = if eltype(ybar) <: Number && u0 isa Array
-            Array(ybar)
-        elseif eltype(ybar) <: Number
-            ybar
-        elseif ybar isa Tangent
-            ut = unthunk.(ybar.u)
-            ut_ = map(ut) do u
-                (u isa ZeroTangent || u isa NoTangent) ? zero(u0) : u
-            end
-            reduce(hcat, ut_)
-        elseif ybar[1] isa Array
-            return Array(ybar)
-        else
-            tmp = vec(ybar.u[1])
-            for i in 2:length(ybar.u)
-                tmp = hcat(tmp, vec(ybar.u[i]))
-            end
-            return reshape(tmp, size(ybar.u[1])..., length(ybar.u))
-        end
-
-        _, u0bar, pbar = pullback(tmp)
-        _u0bar = u0bar
+        # Convert the incoming ChainRules-style cotangent into the Mooncake tangent type of
+        # the primal output (the same conversion `@from_rrule`/`@from_chainrules` use), run
+        # the deferred Mooncake pullback, then convert the resulting Mooncake tangents back
+        # to ChainRules tangents for the caller.
+        ȳ = Mooncake.mooncake_tangent(Mooncake.primal(out), ybar)
+        dfargs = pb!!(Mooncake.rdata(ȳ))
+        _, u0bar_mc, pbar_mc = Mooncake.tuple_map(
+            (f, r) -> Mooncake.tangent(Mooncake.fdata(Mooncake.tangent(f)), r), fx, dfargs
+        )
+        _u0bar = Mooncake.to_cr_tangent(u0bar_mc)
+        pbar = Mooncake.to_cr_tangent(pbar_mc)
 
         return if originator isa SciMLBase.TrackerOriginator ||
                 originator isa SciMLBase.ReverseDiffOriginator
@@ -236,9 +235,120 @@ function SciMLBase._concrete_solve_adjoint(
         end
     end
 
-    u = state_values(out)
-    return SciMLBase.sensitivity_solution(out, u, current_time(out)),
+    out_primal = Mooncake.primal(out)
+    u = state_values(out_primal)
+    return SciMLBase.sensitivity_solution(out_primal, u, current_time(out_primal)),
         mooncake_adjoint_backpass
+end
+
+# ============================================================================
+# Mooncake-native `solve_up` rule for `MooncakeAdjoint`
+#
+# The `_concrete_solve_adjoint(..., ::MooncakeAdjoint, ...)` method above conforms to the
+# ChainRulesCore.rrule contract, which forces Mooncake's generic `@from_rrule`-based
+# `solve_up` primitive (`DiffEqBaseMooncakeExt.jl`) to round-trip the output cotangent
+# through `mooncake_tangent`/`to_cr_tangent`. `mooncake_tangent` only has methods for
+# simple array/scalar/tuple primals (see AGENTS.md's restriction on `@from_rrule`/
+# `@from_chainrules`), so it has no case for a struct as deeply nested as `ODESolution`,
+# and that conversion throws `ArgumentError: ... does not currently have a method of
+# mooncake_tangent`.
+#
+# `MooncakeAdjoint`'s own gradient computation never leaves Mooncake's native
+# representation in the first place, so there's no need to go anywhere near ChainRules
+# here at all. This is a direct `Mooncake.rrule!!` for `solve_up` restricted to
+# `sensealg::MooncakeAdjoint`, mirroring the `_MooncakeOverAnotherADSensealg` pattern
+# below, but computing the adjoint via a *nested* Mooncake `build_rrule` call instead of
+# delegating to a foreign-AD-backed ChainRules pullback -- so the whole round trip stays
+# in native fdata/rdata. The nested call reuses the incoming `u0`/`p` CoDuals' fdata
+# directly (rather than allocating fresh tangents), so in-place fdata accumulation still
+# lands in the same, potentially-aliased buffers the surrounding reverse pass expects
+# (see the "Aliasing Invariant" in docs/src/understanding_mooncake/rule_system.md).
+function _solve_up_mooncake_native_forwardpass(prob, alg_and_rest, kwargs, _u0, _p)
+    _prob = remake(prob; u0 = _u0, p = _p)
+    sol = solve(
+        _prob, alg_and_rest...; sensealg = DiffEqBase.SensitivityADPassThrough(), kwargs...
+    )
+    return SciMLBase.sensitivity_solution(sol, state_values(sol), current_time(sol))
+end
+
+function _solve_up_mooncake_native(
+        prob, sensealg, u0::Mooncake.CoDual, p::Mooncake.CoDual, alg_and_rest...; kwargs...
+    )
+    forwardpass(_u0, _p) = _solve_up_mooncake_native_forwardpass(
+        prob, alg_and_rest, kwargs, _u0, _p
+    )
+    rule = Mooncake.build_rrule(forwardpass, Mooncake.primal(u0), Mooncake.primal(p))
+    fx_fwds = (
+        Mooncake.CoDual(forwardpass, Mooncake.fdata(Mooncake.zero_tangent(forwardpass))),
+        u0, p,
+    )
+    out, pb!! = Mooncake.__call_rule(rule, fx_fwds)
+    function native_pb!!(y_rdata)
+        _, u0_rdata, p_rdata = pb!!(y_rdata)
+        return u0_rdata, p_rdata
+    end
+    return Mooncake.primal(out), Mooncake.tangent(out), native_pb!!
+end
+
+function Mooncake.rrule!!(
+        f::Mooncake.CoDual{typeof(DiffEqBase.solve_up)},
+        prob::Mooncake.CoDual{<:DiffEqBase.AbstractDEProblem},
+        sensealg::Mooncake.CoDual{<:MooncakeAdjoint},
+        u0::Mooncake.CoDual, p::Mooncake.CoDual, alg_and_rest::Mooncake.CoDual...,
+    )
+    fargs = (f, prob, sensealg, u0, p, alg_and_rest...)
+    primals = Mooncake.tuple_map(Mooncake.primal, fargs)
+    lazy_rdata = Mooncake.tuple_map(Mooncake.lazy_zero_rdata, primals)
+    y_primal, y_fdata, native_pb!! = _solve_up_mooncake_native(
+        primals[2], primals[3], u0, p, primals[6:end]...
+    )
+
+    function pb!!(y_rdata)
+        u0_rdata, p_rdata = native_pb!!(y_rdata)
+        return (
+            Mooncake.instantiate(lazy_rdata[1]),
+            Mooncake.instantiate(lazy_rdata[2]),
+            Mooncake.instantiate(lazy_rdata[3]),
+            u0_rdata,
+            p_rdata,
+            Mooncake.tuple_map(Mooncake.instantiate, lazy_rdata[6:end])...,
+        )
+    end
+
+    return Mooncake.CoDual(y_primal, y_fdata), pb!!
+end
+
+function Mooncake.rrule!!(
+        ::Mooncake.CoDual{typeof(Core.kwcall)},
+        kwargs::Mooncake.CoDual{<:NamedTuple},
+        f::Mooncake.CoDual{typeof(DiffEqBase.solve_up)},
+        prob::Mooncake.CoDual{<:DiffEqBase.AbstractDEProblem},
+        sensealg::Mooncake.CoDual{<:MooncakeAdjoint},
+        u0::Mooncake.CoDual, p::Mooncake.CoDual, alg_and_rest::Mooncake.CoDual...,
+    )
+    fargs = (f, prob, sensealg, u0, p, alg_and_rest...)
+    primals = Mooncake.tuple_map(Mooncake.primal, fargs)
+    lazy_rdata = Mooncake.tuple_map(Mooncake.lazy_zero_rdata, primals)
+    kwargs_p = Base.structdiff(Mooncake.primal(kwargs), NamedTuple{(:originator,)})
+    y_primal, y_fdata, native_pb!! = _solve_up_mooncake_native(
+        primals[2], primals[3], u0, p, primals[6:end]...; kwargs_p...
+    )
+    kwargs_rdata = Mooncake.rdata(Mooncake.zero_tangent(Mooncake.primal(kwargs)))
+
+    function pb!!(y_rdata)
+        u0_rdata, p_rdata = native_pb!!(y_rdata)
+        args_rdata = (
+            Mooncake.instantiate(lazy_rdata[1]),
+            Mooncake.instantiate(lazy_rdata[2]),
+            Mooncake.instantiate(lazy_rdata[3]),
+            u0_rdata,
+            p_rdata,
+            Mooncake.tuple_map(Mooncake.instantiate, lazy_rdata[6:end])...,
+        )
+        return Mooncake.NoRData(), kwargs_rdata, args_rdata...
+    end
+
+    return Mooncake.CoDual(y_primal, y_fdata), pb!!
 end
 
 # Mooncake stacked over ReverseDiffAdjoint/TrackerAdjoint/ForwardSensitivity

--- a/ext/SciMLSensitivityMooncakeExt.jl
+++ b/ext/SciMLSensitivityMooncakeExt.jl
@@ -35,7 +35,7 @@ end
 # function of u0/p, but its body has a try/catch Mooncake's forward-mode compiler can't
 # trace. Zero-derivative keeps Mooncake from ever looking inside.
 @zero_derivative(
-    MinimalCtx, Tuple{typeof(SciMLSensitivity.automatic_sensealg_choice),Vararg},
+    MinimalCtx, Tuple{typeof(SciMLSensitivity.automatic_sensealg_choice), Vararg},
 )
 
 # Mooncake-native gradient for the DAE/ODE init path. Avoids pulling Zygote
@@ -477,7 +477,7 @@ function rrule!!(
         sensealg::CoDual{<:_MooncakeUnsupportedAnotherADSensealg},
         ::CoDual, ::CoDual, ::CoDual...,
     )
-    _mooncake_another_ad_backend_unsupported(Mooncake.primal(sensealg))
+    return _mooncake_another_ad_backend_unsupported(Mooncake.primal(sensealg))
 end
 
 function rrule!!(
@@ -488,7 +488,7 @@ function rrule!!(
         sensealg::CoDual{<:_MooncakeUnsupportedAnotherADSensealg},
         ::CoDual, ::CoDual, ::CoDual...,
     )
-    _mooncake_another_ad_backend_unsupported(Mooncake.primal(sensealg))
+    return _mooncake_another_ad_backend_unsupported(Mooncake.primal(sensealg))
 end
 
 # Forward-mode primitive for `DiffEqBase._solve_adjoint` under ReverseDiffAdjoint and
@@ -529,7 +529,7 @@ function frule!!(
         ::Dual{<:SciMLBase.MooncakeOriginator},
         ::Dual...,
     )
-    _mooncake_solve_adjoint_forward_mode_unsupported(Mooncake.primal(sensealg))
+    return _mooncake_solve_adjoint_forward_mode_unsupported(Mooncake.primal(sensealg))
 end
 
 @is_primitive(
@@ -550,7 +550,7 @@ function frule!!(
         ::Dual{<:SciMLBase.MooncakeOriginator},
         ::Dual...,
     )
-    _mooncake_solve_adjoint_forward_mode_unsupported(Mooncake.primal(sensealg))
+    return _mooncake_solve_adjoint_forward_mode_unsupported(Mooncake.primal(sensealg))
 end
 
 # ForwardSensitivity's HVP is also unsupported, but not for the ReverseDiff/Tracker
@@ -585,7 +585,7 @@ function frule!!(
         ::Dual{<:SciMLBase.MooncakeOriginator},
         ::Dual...,
     )
-    _mooncake_forward_sensitivity_hvp_unsupported()
+    return _mooncake_forward_sensitivity_hvp_unsupported()
 end
 
 @is_primitive(
@@ -606,7 +606,7 @@ function frule!!(
         ::Dual{<:SciMLBase.MooncakeOriginator},
         ::Dual...,
     )
-    _mooncake_forward_sensitivity_hvp_unsupported()
+    return _mooncake_forward_sensitivity_hvp_unsupported()
 end
 
 end

--- a/test/Core1/concrete_solve_derivatives.jl
+++ b/test/Core1/concrete_solve_derivatives.jl
@@ -28,6 +28,11 @@ function gradient_mooncake(f, x)
     return Mooncake.value_and_gradient!!(Mooncake.build_rrule(f, x), f, x)[2][2]
 end
 
+function hvp_mooncake(f, x)
+    cache = Mooncake.prepare_hvp_cache(f, x)
+    return Mooncake.value_and_hvp!!(cache, f, ones(length(x)), x)
+end
+
 function gradient_forwarddiff(f, x)
     return ForwardDiff.gradient(f, x)
 end
@@ -443,21 +448,46 @@ Tests callable structs with different AD backends
         end
     end
 
-    # Mooncake over another AD's adjoint (`ReverseDiffAdjoint`/`TrackerAdjoint`,
-    # and `ForwardSensitivity` below) previously hit a typeassert (or hung
-    # under coverage instrumentation): `set_mooncakeoriginator_if_mooncake`
-    # gets constant-folded away, so `solve_up` never saw `MooncakeOriginator()`
-    # here. Fixed with hand-written `Mooncake.rrule!!`s for `solve_up` in
-    # SciMLSensitivityMooncakeExt.jl that construct it directly. See #1510,
-    # chalk-lab/Mooncake.jl#1208.
+    # Mooncake over another AD's adjoint (`ReverseDiffAdjoint`/`TrackerAdjoint`, and
+    # `ForwardSensitivity` below) via the dedicated `MooncakeOriginator` dispatch added
+    # in #1420: the plain gradient re-solves with a `MooncakeOriginator()` originator so
+    # the delegated ReverseDiff/Tracker pullback never has to round-trip through
+    # Mooncake's own tangent conversion. See #1510 for the history here.
     @testset "Mooncake with ReverseDiffAdjoint" begin
-        result = gradient_mooncake(senseloss(ReverseDiffAdjoint()), u0p)
-        @test result ≈ ref_grad_senseloss
+        @test gradient_mooncake(senseloss(ReverseDiffAdjoint()), u0p) ≈
+            ref_grad_senseloss
+        # HVP is a separate story from the plain gradient above: it needs Mooncake to
+        # forward-mode differentiate through ReverseDiff's own internals, which isn't
+        # safe, so this errors clearly instead (SciML/SciMLSensitivity.jl#1427).
+        @test_throws "can't compute a Hessian-vector product" hvp_mooncake(
+            senseloss(ReverseDiffAdjoint()), u0p
+        )
     end
 
     @testset "Mooncake with TrackerAdjoint" begin
-        result = gradient_mooncake(senseloss(TrackerAdjoint()), u0p)
-        @test result ≈ ref_grad_senseloss
+        @test gradient_mooncake(senseloss(TrackerAdjoint()), u0p) ≈
+            ref_grad_senseloss
+        @test_throws "can't compute a Hessian-vector product" hvp_mooncake(
+            senseloss(TrackerAdjoint()), u0p
+        )
+    end
+
+    @testset "Mooncake with EnzymeAdjoint" begin
+        # Unlike ReverseDiffAdjoint/TrackerAdjoint above, this fails even for a plain
+        # gradient -- a type mismatch inside Mooncake's own rule machinery, unrelated to
+        # the HVP-specific reason those two error for.
+        @test_throws "not currently supported under Mooncake" gradient_mooncake(
+            senseloss(EnzymeAdjoint()), u0p
+        )
+    end
+
+    @testset "Mooncake with ZygoteAdjoint" begin
+        # Also fails even for a plain gradient, but for a third, different reason: Zygote
+        # can't differentiate through a mutating array operation inside solve()'s own
+        # internals, unrelated to anything in this extension.
+        @test_throws "not currently supported under Mooncake" gradient_mooncake(
+            senseloss(ZygoteAdjoint()), u0p
+        )
     end
 
     # Test with p-only differentiation (senseloss3 and senseloss4 from alternative_ad_frontend.jl)
@@ -497,6 +527,14 @@ Tests callable structs with different AD backends
             result = gradient_mooncake(senseloss_p(sensealg), p_only)
             @test result ≈ ref_grad_p
         end
+        # ForwardSensitivity's HVP fails for a third reason, different from
+        # ReverseDiffAdjoint/TrackerAdjoint above: it doesn't delegate to another AD
+        # package at all, but forward-mode tracing into its own ForwardDiff.jl-based
+        # Jacobian machinery hits a Mooncake type-prediction limitation
+        # (chalk-lab/Mooncake.jl#1209). See SciML/SciMLSensitivity.jl#1427.
+        @test_throws "can't compute a Hessian-vector product" hvp_mooncake(
+            senseloss_p(ForwardSensitivity()), p_only
+        )
     end
 end
 

--- a/test/Core1/concrete_solve_derivatives.jl
+++ b/test/Core1/concrete_solve_derivatives.jl
@@ -448,6 +448,19 @@ Tests callable structs with different AD backends
         end
     end
 
+    @testset "Mooncake with MooncakeAdjoint" begin
+        @test gradient_mooncake(senseloss(MooncakeAdjoint()), u0p) ≈
+            ref_grad_senseloss
+        # Independent HVP ground truth: nested ForwardDiff over the whole loss, not
+        # going through any adjoint sensealg at all.
+        ref_hvp = ForwardDiff.gradient(
+            uu -> sum(ForwardDiff.gradient(senseloss(InterpolatingAdjoint()), uu)),
+            u0p
+        )
+        _, _, hvp = hvp_mooncake(senseloss(MooncakeAdjoint()), u0p)
+        @test hvp ≈ ref_hvp
+    end
+
     # Mooncake over another AD's adjoint (`ReverseDiffAdjoint`/`TrackerAdjoint`, and
     # `ForwardSensitivity` below) via the dedicated `MooncakeOriginator` dispatch added
     # in #1420: the plain gradient re-solves with a `MooncakeOriginator()` originator so

--- a/test/QA/aqua.jl
+++ b/test/QA/aqua.jl
@@ -53,6 +53,13 @@ run_qa(
                 :convert_tspan, :current_time, :get_cb_paramjac_config,
                 :get_paramjac_config, :has_continuous_callback, :mooncake_run_ad,
                 :state_values,
+                # SciMLSensitivityMooncakeExt: Mooncake's rule-writing API, explicitly
+                # imported (`import Mooncake: ...`) for the native `MooncakeAdjoint`
+                # `solve_up` rule. There is no public spelling for writing a Mooncake
+                # rule (see the matching comment in all_qualified_accesses_are_public
+                # below); ignore until Mooncake marks its rule API public.
+                :(var"@is_primitive"), :(var"@zero_derivative"), :CoDual, :ForwardMode,
+                :MinimalCtx, Symbol("frule!!"), Symbol("rrule!!"),
             ),
         ),
         # Non-public names of upstream deps accessed qualified in the source; ignore
@@ -62,12 +69,12 @@ run_qa(
                 # ArrayInterface
                 :parameterless_type,
                 # Base
-                :(var"@pure"), :_nt_names, :diff_names, :structdiff,
+                :(var"@pure"), :_nt_names, :diff_names, :inferencebarrier, :structdiff,
                 # Core
                 :kwcall,
                 # DiffEqBase (internal `solve_up`/`_solve_adjoint` rrule plumbing
                 # used by SciMLSensitivityMooncakeExt)
-                :_solve_adjoint, :solve_up,
+                :AbstractDEProblem, :_solve_adjoint, :solve_up,
                 # DiffEqCallbacks
                 :PeriodicCallbackAffect,
                 # DiffEqNoiseProcess
@@ -89,10 +96,10 @@ run_qa(
                 # LinearSolve
                 :needs_concrete_A,
                 # Mooncake (internal tangent/rrule API used by SciMLSensitivityMooncakeExt)
-                :CoDual, :NoFData, :NoRData, :Tangent, :build_rrule, :fdata,
-                :increment_and_get_rdata!, :instantiate, :lazy_zero_rdata, :primal,
-                :rdata, :rrule!!, :tangent, :tangent_to_primal!!, :to_cr_tangent,
-                :tuple_map, :zero_rdata, :zero_tangent,
+                :CoDual, :NoRData, :Tangent, :build_rrule, :fdata,
+                :increment_and_get_rdata!, :instantiate, :lazy_zero_rdata,
+                :mooncake_tangent, :primal, :rdata, :rrule!!, :tangent,
+                :tangent_to_primal!!, :to_cr_tangent, :to_fwds, :tuple_map, :zero_tangent,
                 # OrdinaryDiffEqCore
                 :alg_autodiff, :default_linear_interpolation,
                 # ReverseDiff
@@ -110,6 +117,8 @@ run_qa(
                 :enable_interpolation_sensitivitymode,
                 :has_initialization_data, :has_observed, :has_paramjac, :has_vjp_p,
                 :initialization_status, :sensitivity_solution, :specialization,
+                # SciMLSensitivity (own internal, accessed qualified from the extension)
+                :automatic_sensealg_choice,
                 # SciMLStructures
                 :replace,
                 # SparseArrays

--- a/test/QA/aqua.jl
+++ b/test/QA/aqua.jl
@@ -53,11 +53,7 @@ run_qa(
                 :convert_tspan, :current_time, :get_cb_paramjac_config,
                 :get_paramjac_config, :has_continuous_callback, :mooncake_run_ad,
                 :state_values,
-                # SciMLSensitivityMooncakeExt: Mooncake's rule-writing API, explicitly
-                # imported (`import Mooncake: ...`) for the native `MooncakeAdjoint`
-                # `solve_up` rule. There is no public spelling for writing a Mooncake
-                # rule (see the matching comment in all_qualified_accesses_are_public
-                # below); ignore until Mooncake marks its rule API public.
+                # Mooncake
                 :(var"@is_primitive"), :(var"@zero_derivative"), :CoDual, :ForwardMode,
                 :MinimalCtx, Symbol("frule!!"), Symbol("rrule!!"),
             ),


### PR DESCRIPTION
This is about getting Mooncake's HVP (`value_and_hvp!!`) actually working for SciMLSensitivity, and explicitly erroring out where not supported. closes/addresses SciML/SciMLSensitivity.jl#1427, the following PR gives a baseline for future work into supporting other AD backends as well.

## `MooncakeAdjoint` sensealg

`MooncakeAdjoint`'s gradient was going through the generic `@from_rrule`-based `solve_up` primitive, which round-trips through `mooncake_tangent`/`to_cr_tangent` for ChainRules compatibility. That conversion has no case for something as deeply nested as an `ODESolution`, so it throws.

Since `MooncakeAdjoint`'s gradient never actually needs to leave Mooncake's native tangent representation, this adds a dedicated `rrule!!` for `solve_up` restricted to `MooncakeAdjoint`, built around a nested `Mooncake.build_rrule` call instead of going through ChainRules at all. Gradient and HVP both work correctly now, verified against ForwardDiff on a neural ODE (see `"Mooncake with MooncakeAdjoint"` in `test/Core1/concrete_solve_derivatives.jl`).

## Other `sensealgs`

`value_and_hvp!!` only actually works for `MooncakeAdjoint`. Before this PR, every other sensealg either crashed with a confusing internal stacktrace or, worse, could silently give the wrong HVP. Each one now fails with an explicit, accurate error instead:

- `ReverseDiffAdjoint`/`TrackerAdjoint` hand their gradient off to ReverseDiff.jl/Tracker.jl, and Mooncake can't safely forward-differentiate through another AD tool's internals. Plain gradients are untouched and still work (via the existing `MooncakeOriginator`-based dispatch from #1420/#1510).
- `ForwardSensitivity` doesn't delegate to another AD package, but forward-mode tracing into its own ForwardDiff.jl-based Jacobian machinery hits a Mooncake type-prediction limitation (chalk-lab/Mooncake.jl#1209). Its plain gradient still works too.
- `EnzymeAdjoint`/`ZygoteAdjoint` never actually worked under Mooncake at all, even for a plain gradient, confirmed by direct testing -- for two unrelated reasons. They now say so instead of crashing.

Also removed a dead forward-mode `solve_up` rule that turned out to be unreachable: neither `MooncakeAdjoint`'s nor the other sensealgs' reverse rules ever call back into `solve_up` internally during HVP composition, so a forward-mode primitive sitting there could never fire. And swapped a dependency on Mooncake's internal `__call_rule` for a small local equivalent -- identical on Julia >= 1.11, and keeps the same Julia 1.10 compiler-bug workaround Mooncake's own version has.

## Tests

Added/updated coverage in `test/Core1/concrete_solve_derivatives.jl` for all five sensealgs' behavior under Mooncake described above, including un-skipping a few plain-gradient tests that turned out to already be passing. This now includes the `"Mooncake with MooncakeAdjoint"` gradient+HVP test itself (both checked against an independent nested-`ForwardDiff` ground truth), previously staged separately.

Also fixes the QA/ExplicitImports ignore list for the new Mooncake symbols this PR's rewrite introduces (`mooncake_tangent`, `to_fwds`, the explicitly-imported rule-writing API, etc.) -- this was the direct cause of the QA CI failure on earlier pushes.

## Dependencies

The `"Mooncake with MooncakeAdjoint"` HVP test needs three prerequisite PRs fixing separate forward-mode gaps it exercises (HVP is forward-over-reverse, so it hits code paths a plain reverse-mode gradient never touches):
- SciML/OrdinaryDiffEq.jl#4201 (`promote_f` as an opaque Mooncake primitive) -- **merged**
- SciML/OrdinaryDiffEq.jl#4202 (Mooncake primitive rule for `initialize_saveat`) -- **merged**
- SciML/FunctionWrappersWrappers.jl#84 (forward-mode rules for calling a `FunctionWrappersWrapper`) -- open, mergeable, blocked only by a QA ignore-list gap (fix pushed)

chalk-lab/Mooncake.jl#1259 (three tangent-construction crashes hit while debugging this) has also landed and is merged.

Until #84 merges and is released, the `MooncakeAdjoint` HVP test may still fail in CI on a `FunctionWrapper`/forward-mode gap; the plain-gradient tests and the other four sensealgs' explicit-error tests do not depend on it.