### PR TITLE
Test: import ensemble algorithms from SciMLBase

### DIFF
--- a/test/Core4/distributed.jl
+++ b/test/Core4/distributed.jl
@@ -1,4 +1,5 @@
 using Test, Distributed
+using SciMLBase: EnsembleDistributed
 
 # These tests require AD differentiation through distributed ensemble solves
 # Mooncake doesn't have the necessary rules yet, and Zygote has compatibility

--- a/test/Core4/ensembles.jl
+++ b/test/Core4/ensembles.jl
@@ -1,5 +1,6 @@
 using SciMLSensitivity, OrdinaryDiffEq, Optimization, OptimizationOptimisers, Test
 using ADTypes
+using SciMLBase: EnsembleSerial, EnsembleThreads
 
 # These tests differentiate through ensemble solves. Zygote segfaults on Julia
 # 1.12+ (#1325), so use Enzyme, which differentiates the ODE `EnsembleProblem`


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Import `EnsembleSerial`, `EnsembleThreads`, and `EnsembleDistributed` directly from SciMLBase in the Core4 tests. OrdinaryDiffEq v7 intentionally stopped reexporting those SciMLBase-owned APIs, so the tests failed before exercising the ensemble sensitivity behavior they cover.

Fixes https://github.com/SciML/SciMLSensitivity.jl/issues/1587 and the sibling `EnsembleDistributed` failure visible in:

- https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/31495340381/job/93791507143
- https://github.com/SciML/SciMLBase.jl/actions/runs/31473705795/job/93722498875
- https://github.com/SciML/SciMLBase.jl/actions/runs/31487685218/job/93766743308

## Verification

### Failing before

On SciMLSensitivity `9573732fb738879d8f754cc325996ae0f5b95d05`, SciMLBase `76f50c90359f08190147bc36e4c30e8cf79c959e`, OrdinaryDiffEq 7.3.0, and Julia 1.10.11:

```sh
JULIA_DEPOT_PATH="$PWD/.sensitivity-core4-depot" JULIA_PKG_PRECOMPILE_AUTO=0 JULIA_NUM_THREADS=2 timeout 3600 ~/.juliaup/bin/julia +1.10 --project=.sensitivity-core4-env -e 'include(".sensitivity-core4-sensitivity/test/Core4/ensembles.jl")'
```

exited 1:

```text
ERROR: LoadError: UndefVarError: `EnsembleSerial` not defined
in expression starting at .../test/Core4/ensembles.jl:17
```

### Passing after

The identical command exited 0:

```text
Test Summary:                     | Pass  Total     Time
1: EnsembleAlg = EnsembleSerial() |    1      1  8m05.8s
Test Summary:                      | Pass  Total     Time
2: EnsembleAlg = EnsembleThreads() |    1      1  1m01.5s
Test Summary:                     | Pass  Total   Time
3: EnsembleAlg = EnsembleSerial() |    1      1  10.2s
```

The distributed file also exited 0:

```sh
JULIA_DEPOT_PATH="$PWD/.sensitivity-core4-depot" JULIA_PKG_PRECOMPILE_AUTO=0 JULIA_NUM_THREADS=2 timeout 3600 ~/.juliaup/bin/julia +1.10 --project=.sensitivity-core4-env -e 'include(".sensitivity-core4-sensitivity/test/Core4/distributed.jl")'
```

```text
l1 = 11050.121724581397
[ Info: 187.94399271727218
```

Full group and QA:

```sh
GROUP=Core4 JULIA_DEPOT_PATH="$PWD/.sensitivity-core4-depot" JULIA_PKG_PRECOMPILE_AUTO=0 JULIA_NUM_THREADS=2 timeout 7200 ~/.juliaup/bin/julia +1.10 --project=.sensitivity-core4-env -e 'using Pkg; Pkg.test("SciMLSensitivity"; coverage=false)'
# Test Summary: | Pass  Total      Time
# Core 4        |   17     17  67m30.5s
# Testing SciMLSensitivity tests passed

GROUP=QA JULIA_DEPOT_PATH="$PWD/.sensitivity-core4-depot" JULIA_PKG_PRECOMPILE_AUTO=0 JULIA_NUM_THREADS=2 timeout 3600 ~/.juliaup/bin/julia +1.10 --project=.sensitivity-core4-env -e 'using Pkg; Pkg.test("SciMLSensitivity"; coverage=false)'
# Test Summary:     | Pass  Total      Time
# Quality Assurance |   18     18  10m03.3s
# Testing SciMLSensitivity tests passed

~/.juliaup/bin/julia +1.12 --startup-file=no -m Runic --check test/Core4/ensembles.jl test/Core4/distributed.jl
# exited 0

typos test/Core4/ensembles.jl test/Core4/distributed.jl
# exited 0
```

## Validation caveat

A General-only `Pkg.test` sandbox cannot currently resolve because SciMLSensitivity master requires SciMLTesting 2.8 while General offers only through 2.7.0. The full-group and QA commands above therefore pin SciMLTesting main `9581606210a77393b54e35960b1c21e6b8d4d6de`, whose project version is 2.8.0. The release-order blocker is tracked separately at https://github.com/SciML/SciMLTesting.jl/issues/49; this PR does not weaken the intended compat floor.

Docs were not built because this test-only change does not touch documentation, docstrings, or public API. GPU and other test groups were not run.
