### PR TITLE
style: apply Runic formatting

### DIFF
--- a/src/sensitivity_algorithms.jl
+++ b/src/sensitivity_algorithms.jl
@@ -33,10 +33,13 @@ the dense Jacobian (`autojacvec=false`) branch.
 @inline sensealg_autodiff_as_bool(::AutoFiniteDiff) = false
 @inline sensealg_autodiff_as_bool(::Type{<:AutoFiniteDiff}) = false
 function sensealg_autodiff_as_bool(autodiff)
-    throw(ArgumentError(
-        "sensealg autodiff must be a Bool, AutoForwardDiff, or AutoFiniteDiff; got $(typeof(autodiff)). " *
-        "Use `autodiff=AutoForwardDiff()` (or `true`) for AD Jacobians and " *
-        "`autodiff=AutoFiniteDiff()` (or `false`) for finite-difference Jacobians."))
+    throw(
+        ArgumentError(
+            "sensealg autodiff must be a Bool, AutoForwardDiff, or AutoFiniteDiff; got $(typeof(autodiff)). " *
+                "Use `autodiff=AutoForwardDiff()` (or `true`) for AD Jacobians and " *
+                "`autodiff=AutoFiniteDiff()` (or `false`) for finite-difference Jacobians."
+        )
+    )
 end
 
 

--- a/test/Core1/sensealg_adtypes.jl
+++ b/test/Core1/sensealg_adtypes.jl
@@ -27,16 +27,18 @@ u0 = [1.0]
 tspan = (0.0, 1.0)
 p = [1.5]
 prob = ODEProblem(f, u0, tspan, p)
-sol = solve(prob, Tsit5(), saveat = 0.1, abstol = 1e-6, reltol = 1e-6)
+sol = solve(prob, Tsit5(), saveat = 0.1, abstol = 1.0e-6, reltol = 1.0e-6)
 dg(out, u, p, t, i) = (out .= 1.0)
 for sensealg in (
-    InterpolatingAdjoint(autodiff = AutoFiniteDiff(), autojacvec = false),
-    InterpolatingAdjoint(autodiff = AutoForwardDiff(), autojacvec = false),
-    QuadratureAdjoint(autodiff = AutoForwardDiff(), autojacvec = false),
-    GaussAdjoint(autodiff = AutoForwardDiff(), autojacvec = false),
-)
-    du0, dp = adjoint_sensitivities(sol, Tsit5(); t = sol.t, dgdu_discrete = dg,
-        sensealg = sensealg, abstol = 1e-6, reltol = 1e-6)
+        InterpolatingAdjoint(autodiff = AutoFiniteDiff(), autojacvec = false),
+        InterpolatingAdjoint(autodiff = AutoForwardDiff(), autojacvec = false),
+        QuadratureAdjoint(autodiff = AutoForwardDiff(), autojacvec = false),
+        GaussAdjoint(autodiff = AutoForwardDiff(), autojacvec = false),
+    )
+    du0, dp = adjoint_sensitivities(
+        sol, Tsit5(); t = sol.t, dgdu_discrete = dg,
+        sensealg = sensealg, abstol = 1.0e-6, reltol = 1.0e-6
+    )
     @test length(dp) == length(p)
     @test all(isfinite, dp)
 end


### PR DESCRIPTION
## What changed

Applies Runic 1.7.0 formatting to the two files made noncanonical by
https://github.com/SciML/SciMLSensitivity.jl/pull/1584. This is formatting only:
no source behavior, tests, or documentation change.

## Verification

- Before: the full tracked-Julia Runic check failed only in these two files on
  clean master `9573732fb738879d8f754cc325996ae0f5b95d05`; the prior commit
  `2fb366ebb462f971cca3113a07f9956ca718a83f` passed the same check.
- After:
  `git ls-files -z -- '*.jl' | xargs -0 --no-run-if-empty /home/crackauc/packages/julias/julia-1.12/bin/julia --project=/home/crackauc/.julia/environments/@runic --startup-file=no -m Runic --check --diff`
  passed across the repository.
- `typos --config _typos.toml src/sensitivity_algorithms.jl test/Core1/sensealg_adtypes.jl`
  passed.
- `git diff --check` passed.
- `GROUP=QA /home/crackauc/packages/julias/julia-1.12/bin/julia --project=. --startup-file=no -e 'using Pkg; Pkg.test(; coverage = false)'`
  passed: `20 passed, 0 failed`.

`GROUP=Core1` is not fully green on clean master: its changed ADTypes subtest
passed, but two pre-existing BouncingBall ReverseDiff/Tracker errors remain.
They are independently reported at https://github.com/SciML/OrdinaryDiffEq.jl/issues/4248;
this PR does not alter that behavior.

Ignore until reviewed by @ChrisRackauckas.
