### PR TITLE
test: import SciMLBase test dependencies directly

### DIFF
--- a/test/Core2/error_messages.jl
+++ b/test/Core2/error_messages.jl
@@ -1,4 +1,5 @@
 using SciMLSensitivity, OrdinaryDiffEq, Zygote
+using SciMLBase: SteadyStateProblem
 using Test, ForwardDiff, SteadyStateDiffEq
 import Tracker, ReverseDiff, ChainRulesCore
 

--- a/test/Core8/mtk.jl
+++ b/test/Core8/mtk.jl
@@ -3,7 +3,7 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
 using OrdinaryDiffEq
 using OrdinaryDiffEqCore
 using OrdinaryDiffEqNonlinearSolve: BrownFullBasicInit
-using SciMLBase: NoInit
+using SciMLBase: CheckInit, NoInit
 using SciMLSensitivity
 using Enzyme
 using Mooncake


### PR DESCRIPTION
## What changed

Imports the two test-only symbols from their public owner, `SciMLBase`:

- `SteadyStateProblem` in `test/Core2/error_messages.jl`
- `CheckInit` in `test/Core8/mtk.jl`

No source, reexports, docs configuration, or formatter files are changed.

## Verification

- Passed: `julia --project=. --startup-file=no -e 'import SciMLBase; using SciMLBase: CheckInit, SteadyStateProblem; ...'` confirmed both public owner imports load.
- Passed: focused Runic check for the two changed files.
- Passed: `typos --config _typos.toml` over the diff.
- Passed: `git diff --check`.

The current suite does not statically audit isolated test-file imports, so a failing-before test for these two missing direct imports was not feasible without adding unrelated test infrastructure.

- Clean master `GROUP=QA`: ExplicitImports passed (6/6), but Aqua persistent-tasks failed (`19 passed, 1 failed`) because its completion log was not created.
- Clean master `GROUP=Core2`: the affected `Error Messages` subtest completed, but the group reached `timeout 3600` in unrelated `Core2/stiff_adjoints.jl`.
- Post-change `GROUP=Core8`: `CheckInit()` was reached successfully, then the Enzyme/MTK workload reached `timeout 3600` at `test/Core8/mtk.jl:215`. It did not report an import error.

Not run: GPU and docs builds; neither is affected by this test-only change.

Ignore until reviewed by @ChrisRackauckas.