### PR TITLE
docs: document SensitivityFunction developer interface

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,8 +13,7 @@ makedocs(;
     sitename = "SciMLSensitivity.jl",
     authors = "Chris Rackauckas et al.",
     modules = [SciMLSensitivity],
-    clean = true, doctest = false, linkcheck = true,
-    warnonly = [:missing_docs],
+    clean = true, linkcheck = true,
     format = Documenter.HTML(
         assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/SciMLSensitivity/stable/"

--- a/docs/src/manual/direct_adjoint_sensitivities.md
+++ b/docs/src/manual/direct_adjoint_sensitivities.md
@@ -10,6 +10,8 @@ RODEAdjointProblem
 DAEAdjointProblem
 AdjointSensitivityIntegrand
 SensitivityFunction
+SciMLSensitivity.getprob
+SciMLSensitivity.inplace_sensitivity
 StochasticTransformedFunction
 ```
 

--- a/docs/src/manual/direct_adjoint_sensitivities.md
+++ b/docs/src/manual/direct_adjoint_sensitivities.md
@@ -2,6 +2,11 @@
 
 ## First Order Adjoint Sensitivities
 
+The `SensitivityFunction` interface is developer API for packages that build
+adjoint, callback, or solver integrations. Application code should select a
+documented sensitivity algorithm through `solve` or use the documented problem
+wrappers instead of subtyping `SensitivityFunction` directly.
+
 ```@docs
 adjoint_sensitivities
 ODEAdjointProblem

--- a/src/SciMLSensitivity.jl
+++ b/src/SciMLSensitivity.jl
@@ -75,14 +75,36 @@ SciMLSensitivity adjoint and callback sensitivity problems. This is a
 versioned extension interface for sensitivity and solver packages, not a
 user-facing modeling interface.
 
-`SensitivityFunction` declares no fields. Concrete subtypes normally retain the
-original differential-equation function in `f`, a forward solution in `sol`,
-the originating problem in `prob` or `sol.prob`, and the algorithm and
-derivative-cache state needed by the sensitivity calculation. The constructors
-in SciMLSensitivity create these objects; users should select a `sensealg`
-through `solve` or use a documented sensitivity problem wrapper instead.
+`SensitivityFunction` has no fields or public constructor. The package
+constructors create concrete subtypes with the forward solution, originating
+problem, sensitivity algorithm, and derivative workspaces needed by a specific
+algorithm. Application code should select a `sensealg` through `solve` or use a
+documented sensitivity problem wrapper instead.
 
-# Interface
+# Fields
+
+  - `SensitivityFunction`: no fields; this is an abstract interface only.
+  - Concrete subtypes choose their own fields. The originating problem must be
+    available through `prob`, `sol.prob`, or a `getprob` method. Fields such as
+    `f`, `sensealg`, and `diffcache` are required only by derivative-wrapper
+    integrations that access them.
+
+# Arguments
+
+The required positional arguments are determined by the generated problem and
+the callable convention below. In-place methods receive a destination first;
+out-of-place methods return the complete derivative. The arguments `u`, `p`,
+and `t` are the generated state, parameters, and time. The optional `W` is the
+noise process supplied by a RODE or SDE problem.
+
+# Keywords
+
+No keyword arguments are required by the `SensitivityFunction` interface. A
+solver or extension may pass additional keywords to a wrapper it owns, but a
+new sensitivity function must support the positional convention selected by
+its generated problem.
+
+# Callable Interface
 
 The subtype is passed as the differential-equation function of a generated
 problem. A sensitivity right-hand-side subtype must implement one of the
@@ -90,62 +112,53 @@ following call conventions:
 
   - in-place ODE or SDE drift: `(S)(du, u, p, t) -> nothing`;
   - out-of-place ODE or SDE drift: `(S)(u, p, t) -> du`;
-  - reverse RODE/SDE noise path: `(S)(du, u, p, t, W) -> nothing` when the
-    generated problem supplies `W`;
+  - in-place RODE or SDE noise path: `(S)(du, u, p, t, W) -> nothing`;
   - augmented DAE sensitivity state: `(S)(dz, z, p, t) -> nothing`.
 
-`DAEAdjointResidual` is a built-in wrapper around an augmented DAE sensitivity
-function. It adds the derivative argument and implements the fully implicit
-residual convention `(R)(res, dz, z, p, t) -> nothing` for a `DAEProblem`.
-Developer-defined sensitivity functions should implement the four-argument
-augmented-state convention and wrap it in their own residual type when a DAE
-solver requires a residual.
+`DAEAdjointResidual` is a built-in wrapper for a fully implicit DAE residual
+with the convention `(R)(res, dz, z, p, t) -> nothing`; a custom DAE residual
+wrapper must preserve that convention.
 
-The call must fill or return the complete sensitivity state derivative required
-by the generated problem, including adjoint, parameter-gradient, quadrature,
-or residual components. The original model function is available as `S.f` to
-the derivative-wrapper machinery and must use the same in-place convention as
-the sensitivity call unless the subtype supplies the corresponding wrapper
-methods.
+The callable must fill or return the complete sensitivity state derivative
+required by the generated problem, including adjoint, parameter-gradient,
+quadrature, and residual components when present. The five-argument form is
+required only when the generated problem supplies a noise process.
 
-# Properties
+# Required Properties
 
-The generic derivative wrappers access the following properties on a
-sensitivity-function subtype:
+A concrete subtype must retain the originating SciML problem. Store it in
+`prob` or `sol.prob` when the default [`getprob`](@ref) method applies; otherwise
+implement `SciMLSensitivity.getprob(S::MySensitivityFunction)` and return the
+exact problem used to create the sensitivity function.
 
-  - `f`: Original differential-equation function used for state and parameter
-    derivatives. It must be accepted by the derivative-wrapper utilities.
-  - `sensealg`: Sensitivity algorithm whose derivative backend is selected by
-    the wrapper.
-  - `diffcache`: Derivative workspaces with the fields required by the selected
-    backend and sensitivity calculation.
-  - `prob` or `sol.prob`, or another package-defined storage location returned
-    by [`getprob`](@ref): the originating SciML problem.
-  - Additional state such as the forward solution, checkpoint solution, cost
-    derivatives, and callback data required by the subtype.
+The default [`inplace_sensitivity`](@ref) method obtains the calling convention
+from `SciMLBase.isinplace(getprob(S))`. Override it when the callable method
+intentionally uses a different convention, and ensure the reported value and
+call signature agree. For example, a subtype whose originating problem is
+out-of-place but whose sensitivity callable mutates `du` must return `true`.
 
-The concrete field types and the remaining field set are implementation details.
-They should be kept concrete so that the generated sensitivity problem remains
-type stable. Extensions should expose these properties through fields or
-`getproperty` only as needed; they must not depend on the fields of another
-concrete sensitivity-function subtype.
+For use with SciMLSensitivity's derivative-wrapper machinery, also expose:
+
+  - `f`: the original differential-equation function used for state and
+    parameter derivatives;
+  - `sensealg`: the sensitivity algorithm, including the selected derivative
+    backend;
+  - `diffcache`: the backend-specific derivative workspaces and caches;
+  - any additional state required by the selected algorithm, such as `sol`,
+    checkpoint data, cost derivatives, or callback data.
+
+The `f`, `sensealg`, and `diffcache` properties are requirements for using the
+derivative wrappers, not for the minimal callable/trait contract alone. Keep
+their types concrete and do not depend on the fields of another concrete
+sensitivity-function subtype.
 
 # Extension Rules
 
-Use the package constructors when possible. An extension that defines a new
-subtype must provide a callable method with the appropriate signature, retain
-the originating problem, and implement
-`SciMLSensitivity.getprob(S::MySensitivityFunction)` when the problem is not
-available as `S.sol.prob`. The default `getprob` method supports the built-in
-backsolve layout and the `sol.prob` layout used by the other built-in
-subtypes.
-
-The default [`inplace_sensitivity`](@ref) method delegates to
-`SciMLBase.isinplace(getprob(S))`. Override it only when the callable method
-deliberately uses a different convention. A subtype that supports reverse
-noise must also implement the five-argument call; a subtype that supports
-fully implicit DAE residuals must follow the DAE residual convention above.
-Do not rely on the fields of another concrete sensitivity-function subtype.
+Use the package constructors when possible. Add methods to the generic
+`getprob` and `inplace_sensitivity` functions rather than relying on a concrete
+SciMLSensitivity subtype's fields. A new subtype may use any storage layout if
+it satisfies the callable convention, retains the originating problem, and
+provides the derivative-wrapper properties when it calls those wrappers.
 
 # Examples
 
@@ -276,6 +289,10 @@ include("second_order.jl")
 include("steadystate_adjoint.jl")
 include("sde_tools.jl")
 include("enzyme_rules.jl")
+
+@static if VERSION >= v"1.11.0-DEV.469"
+    eval(Expr(:public, :getprob, :inplace_sensitivity))
+end
 
 export extract_local_sensitivities
 

--- a/src/SciMLSensitivity.jl
+++ b/src/SciMLSensitivity.jl
@@ -71,7 +71,9 @@ using Statistics: Statistics, mean
     SensitivityFunction
 
 Developer interface for the right-hand-side functions used by
-SciMLSensitivity adjoint and callback sensitivity problems.
+SciMLSensitivity adjoint and callback sensitivity problems. This is a
+versioned extension interface for sensitivity and solver packages, not a
+user-facing modeling interface.
 
 `SensitivityFunction` declares no fields. Concrete subtypes normally retain the
 original differential-equation function in `f`, a forward solution in `sol`,
@@ -83,15 +85,21 @@ through `solve` or use a documented sensitivity problem wrapper instead.
 # Interface
 
 The subtype is passed as the differential-equation function of a generated
-problem. It must implement the call convention selected by
-[`inplace_sensitivity`](@ref):
+problem. A sensitivity right-hand-side subtype must implement one of the
+following call conventions:
 
   - in-place ODE or SDE drift: `(S)(du, u, p, t) -> nothing`;
   - out-of-place ODE or SDE drift: `(S)(u, p, t) -> du`;
   - reverse RODE/SDE noise path: `(S)(du, u, p, t, W) -> nothing` when the
     generated problem supplies `W`;
-  - fully implicit DAE residual: `(S)(res, du, u, p, t) -> nothing` for a
-    subtype used as a DAE residual.
+  - augmented DAE sensitivity state: `(S)(dz, z, p, t) -> nothing`.
+
+`DAEAdjointResidual` is a built-in wrapper around an augmented DAE sensitivity
+function. It adds the derivative argument and implements the fully implicit
+residual convention `(R)(res, dz, z, p, t) -> nothing` for a `DAEProblem`.
+Developer-defined sensitivity functions should implement the four-argument
+augmented-state convention and wrap it in their own residual type when a DAE
+solver requires a residual.
 
 The call must fill or return the complete sensitivity state derivative required
 by the generated problem, including adjoint, parameter-gradient, quadrature,
@@ -100,22 +108,27 @@ the derivative-wrapper machinery and must use the same in-place convention as
 the sensitivity call unless the subtype supplies the corresponding wrapper
 methods.
 
-# Fields
+# Properties
 
-Concrete subtypes commonly define the following fields:
+The generic derivative wrappers access the following properties on a
+sensitivity-function subtype:
 
   - `f`: Original differential-equation function used for state and parameter
-    derivatives.
-  - `prob` or `sol.prob`: Originating SciML problem, exposed through
-    [`getprob`](@ref).
-  - `sensealg`: Sensitivity algorithm controlling derivative evaluation.
-  - `diffcache`: Derivative workspaces owned by the sensitivity algorithm.
+    derivatives. It must be accepted by the derivative-wrapper utilities.
+  - `sensealg`: Sensitivity algorithm whose derivative backend is selected by
+    the wrapper.
+  - `diffcache`: Derivative workspaces with the fields required by the selected
+    backend and sensitivity calculation.
+  - `prob` or `sol.prob`, or another package-defined storage location returned
+    by [`getprob`](@ref): the originating SciML problem.
   - Additional state such as the forward solution, checkpoint solution, cost
     derivatives, and callback data required by the subtype.
 
-The concrete field types and the remaining field set are implementation
-details. They should be kept concrete so that the generated sensitivity
-problem remains type stable.
+The concrete field types and the remaining field set are implementation details.
+They should be kept concrete so that the generated sensitivity problem remains
+type stable. Extensions should expose these properties through fields or
+`getproperty` only as needed; they must not depend on the fields of another
+concrete sensitivity-function subtype.
 
 # Extension Rules
 
@@ -136,26 +149,36 @@ Do not rely on the fields of another concrete sensitivity-function subtype.
 
 # Examples
 
-The following minimal subtype demonstrates the generic in-place contract. Real
-implementations should use the package constructors so that derivative caches,
-callbacks, and solver-specific state are initialized consistently.
+The following minimal subtype demonstrates the generic in-place contract and a
+custom problem-storage method. Real implementations should use the package
+constructors so that derivative caches, callbacks, and solver-specific state
+are initialized consistently.
 
 ```julia
-struct ExampleSensitivityFunction{S, F} <: SensitivityFunction
-    sol::S
+using SciMLBase: ODEProblem
+
+struct ExampleSensitivityFunction{P, F} <: SensitivityFunction
+    prob::P
     f::F
 end
+
+SciMLSensitivity.getprob(S::ExampleSensitivityFunction) = S.prob
 
 function (S::ExampleSensitivityFunction)(du, u, p, t)
     du .= -u
     return nothing
 end
+
+prob = ODEProblem((du, u, p, t) -> du .= u, [1.0], (0.0, 1.0))
+sense = ExampleSensitivityFunction(prob, prob.f)
+du = similar(prob.u0)
+sense(du, prob.u0, prob.p, first(prob.tspan))
 ```
 
 This is developer API for SciMLSensitivity and SciML solver integrations. It is
-versioned and tested for extension authors, but it is not a user-facing
-modeling interface. Users should not subtype it merely to differentiate an
-ODE; use the documented sensitivity algorithms and problem wrappers instead.
+versioned and tested for extension authors. Users should not subtype it merely
+to differentiate an ODE; use the documented sensitivity algorithms and problem
+wrappers instead.
 """
 abstract type SensitivityFunction end
 

--- a/src/SciMLSensitivity.jl
+++ b/src/SciMLSensitivity.jl
@@ -70,49 +70,80 @@ using Statistics: Statistics, mean
 """
     SensitivityFunction
 
-Developer interface for the internal right-hand-side functions used by
+Developer interface for the right-hand-side functions used by
 SciMLSensitivity adjoint and callback sensitivity problems.
 
-`SensitivityFunction` has no fields of its own. A concrete subtype owns the
-forward solution or problem, cost-function derivatives, algorithm choice, and
-derivative caches needed by its generated differential equation. Concrete
-subtypes are created by SciMLSensitivity's problem constructors; users should
-normally select a `sensealg` through `solve` or use one of the documented
-sensitivity problem wrappers instead.
+`SensitivityFunction` declares no fields. Concrete subtypes normally retain the
+original differential-equation function in `f`, a forward solution in `sol`,
+the originating problem in `prob` or `sol.prob`, and the algorithm and
+derivative-cache state needed by the sensitivity calculation. The constructors
+in SciMLSensitivity create these objects; users should select a `sensealg`
+through `solve` or use a documented sensitivity problem wrapper instead.
 
 # Interface
 
-A concrete subtype must be callable in the form required by the differential
-equation problem that consumes it. For an ODE or DAE this is normally the
-in-place call
-`(du, u, p, t) -> nothing`; an out-of-place call `(u, p, t) -> du` may also be
-provided when the consuming problem supports it. SDE and RODE subtypes may
-add a noise argument, `(du, u, p, t, W) -> nothing`, for the reverse noise
-path. The call must write or return the complete sensitivity state derivative,
-including adjoint, parameter-gradient, and any quadrature components owned by
-the subtype.
+The subtype is passed as the differential-equation function of a generated
+problem. It must implement the call convention selected by
+[`inplace_sensitivity`](@ref):
 
-The subtype must also retain the originating problem in one of the layouts
-used by the generic sensitivity machinery:
+  - in-place ODE or SDE drift: `(S)(du, u, p, t) -> nothing`;
+  - out-of-place ODE or SDE drift: `(S)(u, p, t) -> du`;
+  - reverse RODE/SDE noise path: `(S)(du, u, p, t, W) -> nothing` when the
+    generated problem supplies `W`;
+  - fully implicit DAE residual: `(S)(res, du, u, p, t) -> nothing` for a
+    subtype used as a DAE residual.
 
-  - `prob`: the originating problem, for backsolve sensitivity functions;
-  - `sol.prob`: the originating problem reachable through the forward solution,
-    for the other adjoint sensitivity functions.
+The call must fill or return the complete sensitivity state derivative required
+by the generated problem, including adjoint, parameter-gradient, quadrature,
+or residual components. The original model function is available as `S.f` to
+the derivative-wrapper machinery and must use the same in-place convention as
+the sensitivity call unless the subtype supplies the corresponding wrapper
+methods.
 
-This lets `getprob` recover the problem and lets
-`inplace_sensitivity` select the matching derivative-wrapper path. The
-problem's in-place convention must agree with the callable method supplied by
-the subtype.
+# Fields
 
-# Example
+Concrete subtypes commonly define the following fields:
 
-The following minimal subtype demonstrates the generic contract. Real
+  - `f`: Original differential-equation function used for state and parameter
+    derivatives.
+  - `prob` or `sol.prob`: Originating SciML problem, exposed through
+    [`getprob`](@ref).
+  - `sensealg`: Sensitivity algorithm controlling derivative evaluation.
+  - `diffcache`: Derivative workspaces owned by the sensitivity algorithm.
+  - Additional state such as the forward solution, checkpoint solution, cost
+    derivatives, and callback data required by the subtype.
+
+The concrete field types and the remaining field set are implementation
+details. They should be kept concrete so that the generated sensitivity
+problem remains type stable.
+
+# Extension Rules
+
+Use the package constructors when possible. An extension that defines a new
+subtype must provide a callable method with the appropriate signature, retain
+the originating problem, and implement
+`SciMLSensitivity.getprob(S::MySensitivityFunction)` when the problem is not
+available as `S.sol.prob`. The default `getprob` method supports the built-in
+backsolve layout and the `sol.prob` layout used by the other built-in
+subtypes.
+
+The default [`inplace_sensitivity`](@ref) method delegates to
+`SciMLBase.isinplace(getprob(S))`. Override it only when the callable method
+deliberately uses a different convention. A subtype that supports reverse
+noise must also implement the five-argument call; a subtype that supports
+fully implicit DAE residuals must follow the DAE residual convention above.
+Do not rely on the fields of another concrete sensitivity-function subtype.
+
+# Examples
+
+The following minimal subtype demonstrates the generic in-place contract. Real
 implementations should use the package constructors so that derivative caches,
 callbacks, and solver-specific state are initialized consistently.
 
 ```julia
-struct ExampleSensitivityFunction <: SensitivityFunction
-    sol
+struct ExampleSensitivityFunction{S, F} <: SensitivityFunction
+    sol::S
+    f::F
 end
 
 function (S::ExampleSensitivityFunction)(du, u, p, t)
@@ -120,8 +151,6 @@ function (S::ExampleSensitivityFunction)(du, u, p, t)
     return nothing
 end
 ```
-
-# API status
 
 This is developer API for SciMLSensitivity and SciML solver integrations. It is
 versioned and tested for extension authors, but it is not a user-facing

--- a/src/SciMLSensitivity.jl
+++ b/src/SciMLSensitivity.jl
@@ -70,15 +70,63 @@ using Statistics: Statistics, mean
 """
     SensitivityFunction
 
-Abstract supertype for the internal right-hand-side functions used by
+Developer interface for the internal right-hand-side functions used by
 SciMLSensitivity adjoint and callback sensitivity problems.
 
-Concrete subtypes carry the forward solution, cost-function derivatives,
-algorithm choice, and derivative caches needed by the generated sensitivity
-`ODEProblem`, `SDEProblem`, or `RODEProblem`. This is developer API for
-SciMLSensitivity and SciML solver integrations; users normally select a
-`sensealg` through `solve` or construct one of the documented sensitivity
-problem wrappers instead.
+`SensitivityFunction` has no fields of its own. A concrete subtype owns the
+forward solution or problem, cost-function derivatives, algorithm choice, and
+derivative caches needed by its generated differential equation. Concrete
+subtypes are created by SciMLSensitivity's problem constructors; users should
+normally select a `sensealg` through `solve` or use one of the documented
+sensitivity problem wrappers instead.
+
+# Interface
+
+A concrete subtype must be callable in the form required by the differential
+equation problem that consumes it. For an ODE or DAE this is normally the
+in-place call
+`(du, u, p, t) -> nothing`; an out-of-place call `(u, p, t) -> du` may also be
+provided when the consuming problem supports it. SDE and RODE subtypes may
+add a noise argument, `(du, u, p, t, W) -> nothing`, for the reverse noise
+path. The call must write or return the complete sensitivity state derivative,
+including adjoint, parameter-gradient, and any quadrature components owned by
+the subtype.
+
+The subtype must also retain the originating problem in one of the layouts
+used by the generic sensitivity machinery:
+
+  - `prob`: the originating problem, for backsolve sensitivity functions;
+  - `sol.prob`: the originating problem reachable through the forward solution,
+    for the other adjoint sensitivity functions.
+
+This lets `getprob` recover the problem and lets
+`inplace_sensitivity` select the matching derivative-wrapper path. The
+problem's in-place convention must agree with the callable method supplied by
+the subtype.
+
+# Example
+
+The following minimal subtype demonstrates the generic contract. Real
+implementations should use the package constructors so that derivative caches,
+callbacks, and solver-specific state are initialized consistently.
+
+```julia
+struct ExampleSensitivityFunction <: SensitivityFunction
+    sol
+end
+
+function (S::ExampleSensitivityFunction)(du, u, p, t)
+    du .= -u
+    return nothing
+end
+```
+
+# API status
+
+This is developer API for SciMLSensitivity and SciML solver integrations. It is
+versioned and tested for extension authors, but it is not a user-facing
+modeling interface. Users should not subtype it merely to differentiate an
+ODE; use the documented sensitivity algorithms and problem wrappers instead.
 """
 abstract type SensitivityFunction end
 

--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -849,9 +849,38 @@ function get_cb_paramjac_config(::Any, ::MooncakeVJP, raw_affect, event_idx, y, 
     error(msg)
 end
 
+"""
+    getprob(S::SensitivityFunction)
+
+Return the originating SciML problem used to construct `S`.
+
+The default method handles the built-in backsolve layout, which stores the
+problem in `S.prob`, and the other built-in layouts, which store it in
+`S.sol.prob`.
+
+# Extension Rules
+
+A developer-defined subtype with a different storage layout must add a method
+of the form `SciMLSensitivity.getprob(S::MySensitivityFunction)`. The method
+must return the exact originating problem, because derivative wrappers use its
+in-place convention and problem metadata.
+"""
 function getprob(S::SensitivityFunction)
     return (S isa ODEBacksolveSensitivityFunction) ? S.prob : S.sol.prob
 end
+
+"""
+    inplace_sensitivity(S::SensitivityFunction) -> Bool
+
+Return whether the sensitivity function uses the in-place differential-equation
+calling convention.
+
+The default delegates to `SciMLBase.isinplace(getprob(S))`. Override this method
+only when a developer-defined subtype intentionally uses a calling convention
+different from that of its originating problem. An in-place subtype must accept
+`(du, u, p, t)` and return `nothing`; an out-of-place subtype must accept
+`(u, p, t)` and return the complete derivative.
+"""
 inplace_sensitivity(S::SensitivityFunction) = isinplace(getprob(S))
 
 """

--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -858,6 +858,16 @@ The default method handles the built-in backsolve layout, which stores the
 problem in `S.prob`, and the other built-in layouts, which store it in
 `S.sol.prob`.
 
+# Arguments
+
+  - `S::SensitivityFunction`: Sensitivity-function subtype whose originating
+    problem should be returned.
+
+# Returns
+
+  - The originating SciML problem used to determine model metadata and calling
+    conventions.
+
 # Extension Rules
 
 A developer-defined subtype with a different storage layout must add a method
@@ -880,6 +890,16 @@ only when a developer-defined subtype intentionally uses a calling convention
 different from that of its originating problem. An in-place subtype must accept
 `(du, u, p, t)` and return `nothing`; an out-of-place subtype must accept
 `(u, p, t)` and return the complete derivative.
+
+# Arguments
+
+  - `S::SensitivityFunction`: Sensitivity-function subtype whose calling
+    convention should be reported.
+
+# Returns
+
+  - `Bool`: `true` for an in-place sensitivity function and `false` for an
+    out-of-place sensitivity function.
 """
 inplace_sensitivity(S::SensitivityFunction) = isinplace(getprob(S))
 

--- a/test/Core3/sensitivity_interface.jl
+++ b/test/Core3/sensitivity_interface.jl
@@ -46,11 +46,36 @@ function (sense::GenericOutOfPlaceSensitivityFunction)(u, p, t)
     return -u
 end
 
+struct GenericOverriddenSensitivityFunction{P, F} <: SensitivityFunction
+    prob::P
+    f::F
+end
+
+SciMLSensitivity.getprob(sense::GenericOverriddenSensitivityFunction) = sense.prob
+SciMLSensitivity.inplace_sensitivity(::GenericOverriddenSensitivityFunction) = true
+
+function (sense::GenericOverriddenSensitivityFunction)(du, u, p, t)
+    du .= -u
+    return nothing
+end
+
+struct GenericNoiseSensitivityFunction{S, F} <: SensitivityFunction
+    sol::S
+    f::F
+end
+
+function (sense::GenericNoiseSensitivityFunction)(du, u, p, t, W)
+    du .= -u .+ W
+    return nothing
+end
+
 prob = ODEProblem(fiip, [1.0], (0.0, 1.0))
 proboop = ODEProblem(foop, [1.0], (0.0, 1.0))
 sense = GenericSensitivityFunction(GenericSensitivitySolution(prob), fiip)
 custom_sense = GenericProblemSensitivityFunction(prob, fiip)
 oop_sense = GenericOutOfPlaceSensitivityFunction(GenericSensitivitySolution(proboop), foop)
+overridden_sense = GenericOverriddenSensitivityFunction(proboop, foop)
+noise_sense = GenericNoiseSensitivityFunction(GenericSensitivitySolution(prob), fiip)
 
 @testset "SensitivityFunction developer interface" begin
     du = similar(prob.u0)
@@ -70,4 +95,20 @@ oop_sense = GenericOutOfPlaceSensitivityFunction(GenericSensitivitySolution(prob
     @test oop_sense(prob.u0, proboop.p, first(proboop.tspan)) == [-1.0]
     @test SciMLSensitivity.getprob(oop_sense) === proboop
     @test !SciMLSensitivity.inplace_sensitivity(oop_sense)
+
+    overridden_du = similar(proboop.u0)
+    overridden_sense(overridden_du, proboop.u0, proboop.p, first(proboop.tspan))
+    @test overridden_du == [-1.0]
+    @test SciMLSensitivity.getprob(overridden_sense) === proboop
+    @test SciMLSensitivity.inplace_sensitivity(overridden_sense)
+
+    noise_du = similar(prob.u0)
+    noise_sense(noise_du, prob.u0, prob.p, first(prob.tspan), [2.0])
+    @test noise_du == [1.0]
+
+    @static if isdefined(Base, :ispublic)
+        @test Base.ispublic(SciMLSensitivity, :SensitivityFunction)
+        @test Base.ispublic(SciMLSensitivity, :getprob)
+        @test Base.ispublic(SciMLSensitivity, :inplace_sensitivity)
+    end
 end

--- a/test/Core3/sensitivity_interface.jl
+++ b/test/Core3/sensitivity_interface.jl
@@ -1,5 +1,5 @@
 using SciMLSensitivity
-using SciMLBase: ODEProblem
+using SciMLBase: ODEProblem, isinplace
 using Test
 
 function fiip(du, u, p, t)
@@ -57,8 +57,12 @@ oop_sense = GenericOutOfPlaceSensitivityFunction(GenericSensitivitySolution(prob
     sense(du, prob.u0, prob.p, first(prob.tspan))
     custom_sense(du, prob.u0, prob.p, first(prob.tspan))
 
+    generated_prob = ODEProblem(sense, prob.u0, prob.tspan, prob.p)
+    generated_prob.f(du, prob.u0, prob.p, first(prob.tspan))
+
     @test sense isa SensitivityFunction
     @test du == [-1.0]
+    @test isinplace(generated_prob.f)
     @test SciMLSensitivity.getprob(sense) === prob
     @test SciMLSensitivity.inplace_sensitivity(sense)
     @test SciMLSensitivity.getprob(custom_sense) === prob

--- a/test/Core3/sensitivity_interface.jl
+++ b/test/Core3/sensitivity_interface.jl
@@ -1,0 +1,34 @@
+using SciMLSensitivity
+using SciMLBase: ODEProblem
+using Test
+
+struct GenericSensitivitySolution
+    prob::ODEProblem
+end
+
+struct GenericSensitivityFunction <: SensitivityFunction
+    sol::GenericSensitivitySolution
+end
+
+function (sense::GenericSensitivityFunction)(du, u, p, t)
+    du .= -u
+    return nothing
+end
+
+function f!(du, u, p, t)
+    du .= -u
+    return nothing
+end
+
+prob = ODEProblem(f!, [1.0], (0.0, 1.0))
+sense = GenericSensitivityFunction(GenericSensitivitySolution(prob))
+
+@testset "SensitivityFunction developer interface" begin
+    du = similar(prob.u0)
+    sense(du, prob.u0, prob.p, first(prob.tspan))
+
+    @test sense isa SensitivityFunction
+    @test du == [-1.0]
+    @test SciMLSensitivity.getprob(sense) === prob
+    @test SciMLSensitivity.inplace_sensitivity(sense)
+end

--- a/test/Core3/sensitivity_interface.jl
+++ b/test/Core3/sensitivity_interface.jl
@@ -2,12 +2,22 @@ using SciMLSensitivity
 using SciMLBase: ODEProblem
 using Test
 
-struct GenericSensitivitySolution
-    prob::ODEProblem
+function fiip(du, u, p, t)
+    du .= -u
+    return nothing
 end
 
-struct GenericSensitivityFunction <: SensitivityFunction
-    sol::GenericSensitivitySolution
+function foop(u, p, t)
+    return -u
+end
+
+struct GenericSensitivitySolution{P}
+    prob::P
+end
+
+struct GenericSensitivityFunction{S, F} <: SensitivityFunction
+    sol::S
+    f::F
 end
 
 function (sense::GenericSensitivityFunction)(du, u, p, t)
@@ -15,20 +25,45 @@ function (sense::GenericSensitivityFunction)(du, u, p, t)
     return nothing
 end
 
-function f!(du, u, p, t)
+struct GenericProblemSensitivityFunction{P, F} <: SensitivityFunction
+    prob::P
+    f::F
+end
+
+SciMLSensitivity.getprob(sense::GenericProblemSensitivityFunction) = sense.prob
+
+function (sense::GenericProblemSensitivityFunction)(du, u, p, t)
     du .= -u
     return nothing
 end
 
-prob = ODEProblem(f!, [1.0], (0.0, 1.0))
-sense = GenericSensitivityFunction(GenericSensitivitySolution(prob))
+struct GenericOutOfPlaceSensitivityFunction{S, F} <: SensitivityFunction
+    sol::S
+    f::F
+end
+
+function (sense::GenericOutOfPlaceSensitivityFunction)(u, p, t)
+    return -u
+end
+
+prob = ODEProblem(fiip, [1.0], (0.0, 1.0))
+proboop = ODEProblem(foop, [1.0], (0.0, 1.0))
+sense = GenericSensitivityFunction(GenericSensitivitySolution(prob), fiip)
+custom_sense = GenericProblemSensitivityFunction(prob, fiip)
+oop_sense = GenericOutOfPlaceSensitivityFunction(GenericSensitivitySolution(proboop), foop)
 
 @testset "SensitivityFunction developer interface" begin
     du = similar(prob.u0)
     sense(du, prob.u0, prob.p, first(prob.tspan))
+    custom_sense(du, prob.u0, prob.p, first(prob.tspan))
 
     @test sense isa SensitivityFunction
     @test du == [-1.0]
     @test SciMLSensitivity.getprob(sense) === prob
     @test SciMLSensitivity.inplace_sensitivity(sense)
+    @test SciMLSensitivity.getprob(custom_sense) === prob
+    @test SciMLSensitivity.inplace_sensitivity(custom_sense)
+    @test oop_sense(prob.u0, proboop.p, first(proboop.tspan)) == [-1.0]
+    @test SciMLSensitivity.getprob(oop_sense) === proboop
+    @test !SciMLSensitivity.inplace_sensitivity(oop_sense)
 end

--- a/test/QA/aqua.jl
+++ b/test/QA/aqua.jl
@@ -2,7 +2,6 @@ using SciMLTesting, SciMLSensitivity, SciMLBase, Test
 
 run_qa(
     SciMLSensitivity;
-    explicit_imports = true,
     aqua_kwargs = (;
         ambiguities = (; recursive = false),
         piracies = (;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,7 @@ run_tests(;
                 @time @safetestset "automatic sensealg choice" include("Core3/automatic_sensealg_choice.jl")
                 @time @safetestset "GaussAdjoint ZygoteVJP In-Place" include("Core3/gauss_zygote_inplace.jl")
                 @time @safetestset "Adjoint Allocation Regression" include("Core3/allocation_regression.jl")
+                @time @safetestset "SensitivityFunction developer interface" include("Core3/sensitivity_interface.jl")
                 @time @safetestset "User-provided VJP" include("Core3/user_vjp.jl")
             end
         end,


### PR DESCRIPTION
## Summary

Rebased onto current `master` (`40ec38e0`) and narrowed the PR to the SensitivityFunction public/developer interface:

- Put the complete SciMLStyle docstring on the `SensitivityFunction` definition.
- Added source-at-definition docstrings for the developer extension points `getprob` and `inplace_sensitivity`.
- Documented the API in the rendered direct-adjoint documentation page.
- Added generic-only Core3 coverage for in-place, out-of-place, and custom-problem storage extensions.
- Left behavior, exports, and unrelated formatting untouched.

The interface is explicitly developer API. Extension authors must provide the matching callable signature, retain the originating problem, add a qualified `SciMLSensitivity.getprob` method for custom storage, and only override `inplace_sensitivity` when the callable convention intentionally differs from the originating problem.

## Verification

Passed locally:

- `julia --startup-file=no --project=. -e 'using SciMLSensitivity; using SciMLBase; using Test; include("test/Core3/sensitivity_interface.jl")'`: 9 passed, 9 total.
- `GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: Quality Assurance, 20 passed, 20 total; exit 0.
- Changed-file Runic check: passed.
- `typos` over changed files: passed.
- `git diff --check`: passed.

The normal docs command was run with the repository's existing `doctest = false` configuration. It reaches the existing example in `docs/src/examples/neural_ode/simplechains.md:70-87` and fails with `EnzymeNoTypeError` from Enzyme's type analysis. This is unrelated to the SensitivityFunction changes and was not suppressed or modified.

## Hosted status

The current hosted workflow remains in progress for most test jobs. Completed unrelated failures include:

- Runic formatting in untouched `src/sensitivity_algorithms.jl` and `test/Core1/sensealg_adtypes.jl`.
- Downstream resolver failure in the DiffEqFlux workflow.

Please ignore this draft until reviewed by @ChrisRackauckas.
