### PR TITLE
chore: fix runic formatting in sensitivity tests

### DIFF
--- a/src/sensitivity_algorithms.jl
+++ b/src/sensitivity_algorithms.jl
@@ -33,10 +33,13 @@ the dense Jacobian (`autojacvec=false`) branch.
 @inline sensealg_autodiff_as_bool(::AutoFiniteDiff) = false
 @inline sensealg_autodiff_as_bool(::Type{<:AutoFiniteDiff}) = false
 function sensealg_autodiff_as_bool(autodiff)
-    throw(ArgumentError(
-        "sensealg autodiff must be a Bool, AutoForwardDiff, or AutoFiniteDiff; got $(typeof(autodiff)). " *
-        "Use `autodiff=AutoForwardDiff()` (or `true`) for AD Jacobians and " *
-        "`autodiff=AutoFiniteDiff()` (or `false`) for finite-difference Jacobians."))
+    throw(
+        ArgumentError(
+            "sensealg autodiff must be a Bool, AutoForwardDiff, or AutoFiniteDiff; got $(typeof(autodiff)). " *
+                "Use `autodiff=AutoForwardDiff()` (or `true`) for AD Jacobians and " *
+                "`autodiff=AutoFiniteDiff()` (or `false`) for finite-difference Jacobians."
+        )
+    )
 end
 
 

--- a/test/Core1/sensealg_adtypes.jl
+++ b/test/Core1/sensealg_adtypes.jl
@@ -27,16 +27,18 @@ u0 = [1.0]
 tspan = (0.0, 1.0)
 p = [1.5]
 prob = ODEProblem(f, u0, tspan, p)
-sol = solve(prob, Tsit5(), saveat = 0.1, abstol = 1e-6, reltol = 1e-6)
+sol = solve(prob, Tsit5(), saveat = 0.1, abstol = 1.0e-6, reltol = 1.0e-6)
 dg(out, u, p, t, i) = (out .= 1.0)
 for sensealg in (
-    InterpolatingAdjoint(autodiff = AutoFiniteDiff(), autojacvec = false),
-    InterpolatingAdjoint(autodiff = AutoForwardDiff(), autojacvec = false),
-    QuadratureAdjoint(autodiff = AutoForwardDiff(), autojacvec = false),
-    GaussAdjoint(autodiff = AutoForwardDiff(), autojacvec = false),
-)
-    du0, dp = adjoint_sensitivities(sol, Tsit5(); t = sol.t, dgdu_discrete = dg,
-        sensealg = sensealg, abstol = 1e-6, reltol = 1e-6)
+        InterpolatingAdjoint(autodiff = AutoFiniteDiff(), autojacvec = false),
+        InterpolatingAdjoint(autodiff = AutoForwardDiff(), autojacvec = false),
+        QuadratureAdjoint(autodiff = AutoForwardDiff(), autojacvec = false),
+        GaussAdjoint(autodiff = AutoForwardDiff(), autojacvec = false),
+    )
+    du0, dp = adjoint_sensitivities(
+        sol, Tsit5(); t = sol.t, dgdu_discrete = dg,
+        sensealg = sensealg, abstol = 1.0e-6, reltol = 1.0e-6
+    )
     @test length(dp) == length(p)
     @test all(isfinite, dp)
 end


### PR DESCRIPTION
## Summary
- Reformat `src/sensitivity_algorithms.jl` and `test/Core1/sensealg_adtypes.jl` to pass runic/format checks on `master`.

## Verification
- `INPUT_RUNIC_EXTENSIONS=jl INPUT_RUNIC_DOCSTRINGS=false julia --project=@runic /tmp/fk_check.jl`
- `typos .`
- Both commands pass on a clean `master` checkout.

## PR notes
- This PR should be ignored until reviewed by @ChrisRackauckas.
