### PR TITLE
Preserve despecialized parameters in adjoint VJPs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLSensitivity"
 uuid = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
-version = "7.118.1"
+version = "7.118.2"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
 [deps]

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -253,6 +253,10 @@ function _f_has_vjp(f)
     return f isa SciMLBase.AbstractSciMLFunction && SciMLBase.has_vjp(f)
 end
 
+_adjoint_parameters(p, ::SciMLBase.DespecializedParameters) =
+    SciMLBase.DespecializedParameters(p)
+_adjoint_parameters(p, _) = p
+
 # `du`/`ddu` are set only for fully implicit DAE residuals F(du, u, p, t): `du` is
 # the derivative evaluation point and `ddu` receives the vjp with respect to it.
 # They thread through the same per-backend `_vecjacobian!` methods as the ODE
@@ -264,6 +268,7 @@ function vecjacobian!(
         dgrad = nothing, dy = nothing,
         W = nothing, du = nothing, ddu = nothing
     ) where {TS <: SensitivityFunction}
+    p = _adjoint_parameters(p, parameter_values(getprob(S)))
     if du === nothing && _f_has_vjp(S.f)
         _vecjacobian_vjp!(dλ, y, λ, p, t, S, dgrad, dy, W)
     else
@@ -285,6 +290,7 @@ function vecjacobian(
         dgrad = nothing, dy = nothing,
         W = nothing
     ) where {TS <: SensitivityFunction}
+    p = _adjoint_parameters(p, parameter_values(getprob(S)))
     if _f_has_vjp(S.f)
         return _vecjacobian_vjp(y, λ, p, t, S, dgrad, dy, W)
     else

--- a/test/Core8/parameter_initialization.jl
+++ b/test/Core8/parameter_initialization.jl
@@ -122,6 +122,29 @@ tunables, repack, _ = SS.canonicalize(SS.Tunable(), parameter_values(prob))
     end
 end
 
+function autodespecialized_rhs!(du, u, p, t)
+    du[1] = -p[1] * u[1]
+    return nothing
+end
+
+@testset "Adjoint with despecialized parameters" begin
+    function loss(p)
+        prob = ODEProblem{true, SciMLBase.AutoDespecialize}(
+            autodespecialized_rhs!, [1.0], (0.0, 1.0), p
+        )
+        sol = solve(
+            prob, Tsit5();
+            sensealg = GaussAdjoint(autojacvec = EnzymeVJP()),
+            abstol = 1.0e-10, reltol = 1.0e-10,
+            saveat = [0.0, 1.0], save_everystep = false,
+        )
+        return sum(sol)
+    end
+
+    grad = only(Zygote.gradient(loss, [0.5]))
+    @test only(grad) ≈ -exp(-0.5) rtol = 1.0e-6
+end
+
 # https://github.com/SciML/SciMLSensitivity.jl/issues/1582
 # `ForwardDiffSensitivity` (the default here: length(u0) + length(tunables) <= 100)
 # seeds `u0` duals, but a problem carrying initialization data re-derives `u0`


### PR DESCRIPTION
## What changed

Restore the parameter wrapper at SciMLSensitivity's central adjoint VJP entry points when the originating problem uses `DespecializedParameters`. AD backends may transform the concrete parameter value before it reaches `vecjacobian!`/`vecjacobian`; rebuilding the public, idempotent wrapper keeps the adjoint caches and backend arguments type-consistent.

This is required by ModelingToolkit's `AutoDespecialize` support in https://github.com/SciML/ModelingToolkit.jl/pull/4919. The complementary transformed-call barrier fix is https://github.com/SciML/OrdinaryDiffEq.jl/pull/4290.

Ignore this PR until reviewed by @ChrisRackauckas.

## Failing before / passing after

The regression differentiates a plain `ODEProblem{true, AutoDespecialize}` using `GaussAdjoint(EnzymeVJP())`.

Before:

```text
MethodError: no method matching EnzymeCore.Duplicated(::Vector{Float64}, ::SciMLBase.DespecializedParameters)
```

After, using registered DiffEqBase 7.15.0:

```text
autodespecialize_adjoint_registered_diffeqbase=pass
grad=[-0.6065306597106055]
```

The gradient agrees with the analytic value `-exp(-0.5)`.

## Verification

```text
GROUP=QA julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Quality Assurance | 20 / 20 | 2m06.8s
Testing SciMLSensitivity tests passed
```

The exact SciMLSensitivity `Core8` downstream environment from https://github.com/SciML/ModelingToolkit.jl/pull/4919 was run with this patch and https://github.com/SciML/OrdinaryDiffEq.jl/pull/4290:

```text
before: Core 8 | 35 pass | 5 error | 5 broken
after:  Core 8 | 45 pass | 5 broken | 50 total | 108m24.9s
Testing SciMLSensitivity tests passed
```

Runic 1.8, added-line `typos`, and `git diff --check` pass.

## Not verified

The full `Core8` group was run with both owner fixes together; the new focused regression was additionally run with registered DiffEqBase 7.15.0 and passed independently. GPU and allowed-to-fail prerelease jobs were not run locally. No public API or documentation changed, so no docs build was required.
