### PR TITLE
Use Vern9 in direct sensitivity tutorial

### DIFF
--- a/docs/src/tutorials/direct_sensitivity.md
+++ b/docs/src/tutorials/direct_sensitivity.md
@@ -28,7 +28,7 @@ prob = SMS.ODEForwardSensitivityProblem(f, [1.0; 1.0], (0.0, 10.0), p)
 This generates a problem which the ODE solvers can solve:
 
 ```@example directsense
-sol = ODE.solve(prob, ODE.DP8())
+sol = ODE.solve(prob, ODE.Vern9())
 ```
 
 Note that the solution is the standard ODE system and the sensitivity system combined.


### PR DESCRIPTION
docs/src/tutorials/direct_sensitivity.md used ODE.DP8(), which the OrdinaryDiffEq umbrella does not export, so the example errors on build. Switched to ODE.Vern9(), matching the other examples in the file.

Closes #1602