### PR TITLE
fix: don't discard the caller's repack in automatic_sensealg_choice

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -215,6 +215,14 @@ function automatic_sensealg_choice(
 
     if p === nothing || p isa SciMLBase.NullParameters
         tunables, repack = p, identity
+    elseif repack !== nothing
+        # The caller has already canonicalized: `p` is the tunables and `repack`
+        # reconstructs the original parameter object. Canonicalizing again would
+        # replace the caller's repack with an identity-like one (e.g.
+        # `SciMLStructures.ArrayRepack` for `MTKParameters`), making every VJP
+        # probe call the RHS with the bare tunables vector instead of the
+        # parameter object it will actually receive. See #1605.
+        tunables = p
     elseif isscimlstructure(p)
         tunables, repack, _ = canonicalize(Tunable(), p)
     elseif isfunctor(p)
@@ -350,7 +358,7 @@ function automatic_sensealg_choice(
             end
         end
     else
-        vjp = inplace_vjp(prob, u0, p, verbose, repack)
+        vjp = inplace_vjp(prob, u0, tunables, verbose, repack)
         if _diff_tunables isa Val{false} && !supports_structured_vjp(vjp)
             vjp = ZygoteVJP()
         end

--- a/test/Core3/automatic_sensealg_choice.jl
+++ b/test/Core3/automatic_sensealg_choice.jl
@@ -61,29 +61,3 @@ let N = 150
     @test sensealg_sparse isa GaussAdjoint
     @test sensealg_sparse.autojacvec isa EnzymeVJP
 end
-
-# Regression test for #1605: `automatic_sensealg_choice` used to re-canonicalize the
-# already-canonical tunables vector, overwriting the caller's repack (e.g. for
-# `MTKParameters`) with an identity-like `ArrayRepack`. Every VJP probe then called the
-# RHS with the bare tunables vector; any RHS reading a non-tunable portion threw in the
-# probe primal, so the chooser silently fell back to numerical VJPs
-# `GaussAdjoint(autodiff = false, autojacvec = false)`. More than 100 tunables are needed
-# to get past the `ForwardDiffSensitivity` short-circuit and reach the probes.
-using ModelingToolkit
-using ModelingToolkit: t_nounits as t, D_nounits as D
-
-let
-    @parameters k[1:128] = 0.01 .* ones(128)
-    @parameters c = 3.0 [tunable = false]
-    @variables x(t) = 1.0
-    @named sys = System([D(x) ~ -c * sum(k) * x], t)
-    sys = mtkcompile(sys)
-    prob = ODEProblem(sys, [], (0.0, 1.0))
-
-    tunables, repack, _ = SciMLStructures.canonicalize(SciMLStructures.Tunable(), prob.p)
-    sensealg_mtk = SciMLSensitivity.automatic_sensealg_choice(
-        prob, prob.u0, tunables, true, repack, prob.p
-    )
-    @test sensealg_mtk isa GaussAdjoint
-    @test !(sensealg_mtk.autojacvec isa Bool)
-end

--- a/test/Core3/automatic_sensealg_choice.jl
+++ b/test/Core3/automatic_sensealg_choice.jl
@@ -61,3 +61,29 @@ let N = 150
     @test sensealg_sparse isa GaussAdjoint
     @test sensealg_sparse.autojacvec isa EnzymeVJP
 end
+
+# Regression test for #1605: `automatic_sensealg_choice` used to re-canonicalize the
+# already-canonical tunables vector, overwriting the caller's repack (e.g. for
+# `MTKParameters`) with an identity-like `ArrayRepack`. Every VJP probe then called the
+# RHS with the bare tunables vector; any RHS reading a non-tunable portion threw in the
+# probe primal, so the chooser silently fell back to numerical VJPs
+# `GaussAdjoint(autodiff = false, autojacvec = false)`. More than 100 tunables are needed
+# to get past the `ForwardDiffSensitivity` short-circuit and reach the probes.
+using ModelingToolkit
+using ModelingToolkit: t_nounits as t, D_nounits as D
+
+let
+    @parameters k[1:128] = 0.01 .* ones(128)
+    @parameters c = 3.0 [tunable = false]
+    @variables x(t) = 1.0
+    @named sys = System([D(x) ~ -c * sum(k) * x], t)
+    sys = mtkcompile(sys)
+    prob = ODEProblem(sys, [], (0.0, 1.0))
+
+    tunables, repack, _ = SciMLStructures.canonicalize(SciMLStructures.Tunable(), prob.p)
+    sensealg_mtk = SciMLSensitivity.automatic_sensealg_choice(
+        prob, prob.u0, tunables, true, repack, prob.p
+    )
+    @test sensealg_mtk isa GaussAdjoint
+    @test !(sensealg_mtk.autojacvec isa Bool)
+end

--- a/test/Core8/mtk.jl
+++ b/test/Core8/mtk.jl
@@ -257,3 +257,26 @@ end
     _, (_, grad) = Mooncake.value_and_gradient!!(rule, loss, tunables_test)
     any(!iszero, grad)
 end
+
+# Regression test for #1605: `automatic_sensealg_choice` used to re-canonicalize the
+# already-canonical tunables vector, overwriting the caller's repack (e.g. for
+# `MTKParameters`) with an identity-like `ArrayRepack`. Every VJP probe then called the
+# RHS with the bare tunables vector; any RHS reading a non-tunable portion threw in the
+# probe primal, so the chooser silently fell back to numerical VJPs
+# `GaussAdjoint(autodiff = false, autojacvec = false)`. More than 100 tunables are needed
+# to get past the `ForwardDiffSensitivity` short-circuit and reach the probes.
+let
+    @parameters k[1:128] = 0.01 .* ones(128)
+    @parameters c = 3.0 [tunable = false]
+    @variables x(t) = 1.0
+    @named sys = System([D(x) ~ -c * sum(k) * x], t)
+    sys = mtkcompile(sys)
+    prob = ODEProblem(sys, [], (0.0, 1.0))
+
+    tunables, repack, _ = SciMLStructures.canonicalize(SciMLStructures.Tunable(), prob.p)
+    sensealg_mtk = SciMLSensitivity.automatic_sensealg_choice(
+        prob, prob.u0, tunables, true, repack, prob.p
+    )
+    @test sensealg_mtk isa GaussAdjoint
+    @test !(sensealg_mtk.autojacvec isa Bool)
+end


### PR DESCRIPTION
Fixes #1605.

## What was wrong

`SciMLBase._concrete_solve_adjoint(..., sensealg::Nothing, ...)` canonicalizes `p` (e.g. `MTKParameters`) into `(tunables, repack)` and calls `automatic_sensealg_choice(prob, u0, tunables, verbose, repack, p)`. Inside, the ODE/SDE method re-canonicalized its `p` argument — which at that point is already the bare tunables `Vector`, and `isscimlstructure(::Vector) == true` — so the caller's repack was overwritten with `SciMLStructures.ArrayRepack` (identity-like).

Every VJP probe in `inplace_vjp` then called the RHS with the bare tunables `Vector` instead of the reconstructed parameter object. For any MTK system whose RHS reads a portion beyond the tunables (a non-tunable parameter, or the `Nonnumeric` portion — where ModelingToolkitNeuralNets stores the Lux chain, i.e. every MTKNN UDE), the probe *primal* throws `BoundsError`, all AD probes "fail", and the chooser silently returns `GaussAdjoint(autodiff = false, autojacvec = false)` — numerical (finite-difference) VJPs. Silent whenever solve-level `verbose` routes to `false`, which is common in downstream libraries.

## The fix

- In the ODE/SDE `automatic_sensealg_choice` method, trust the caller's `(p, repack)` when a `repack` is provided (i.e. `p` is already the canonical tunables), and only self-canonicalize when `repack === nothing` (that entry path is exercised by `test/Core8/parameter_initialization.jl`). This matches what the `ConcreteNonlinearProblem` method already does.
- Pass `tunables` (not `p`) to `inplace_vjp` in the in-place branch, so the self-canonicalizing path also probes with a `(tunables, repack)` pair that actually match.

## Verification

The MWE from #1605 now selects `GaussAdjoint(autojacvec = EnzymeVJP())` instead of `GaussAdjoint(autodiff = false, autojacvec = false)`. Added it (condensed) as a regression test in `test/Core3/automatic_sensealg_choice.jl`: it asserts the chosen `autojacvec` is not a `Bool`, i.e. no silent numerical fallback, without pinning which AD VJP wins the probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
