### PR TITLE
Use SciMLStructures owner alias in Core8 test

### DIFF
--- a/test/Core8/mtk.jl
+++ b/test/Core8/mtk.jl
@@ -273,7 +273,7 @@ let
     sys = mtkcompile(sys)
     prob = ODEProblem(sys, [], (0.0, 1.0))
 
-    tunables, repack, _ = SciMLStructures.canonicalize(SciMLStructures.Tunable(), prob.p)
+    tunables, repack, _ = SS.canonicalize(SS.Tunable(), prob.p)
     sensealg_mtk = SciMLSensitivity.automatic_sensealg_choice(
         prob, prob.u0, tunables, true, repack, prob.p
     )


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

The ModelingToolkit Core8 test already imports the public SciMLStructures owner module as `SS`, but one assertion used the unbound name `SciMLStructures`. The assertion now consistently calls `SS.canonicalize(SS.Tunable(), prob.p)`.

The typo was introduced by https://github.com/SciML/SciMLSensitivity.jl/commit/6a9e8e6cd7cf0b9bf6c898c7234c3051771a7515. It reproduced on unmodified current master in https://github.com/SciML/ModelingToolkit.jl/actions/runs/32902120637/job/97978099857.

## Verification

Failing before on unmodified SciMLSensitivity master (`1bb497ff2af6fa8899c3af0c50848f6e6a14a437`):

```text
$ GROUP=Core8 julia +release --project=. -e 'using Pkg; Pkg.test()'
MTK Forward Mode: Error During Test
LoadError: UndefVarError: `SciMLStructures` not defined
  @ test/Core8/mtk.jl:276
Core 8 | 45 pass, 1 error, 5 broken, 51 total
ERROR: Package SciMLSensitivity errored during testing
```

Passing after with the same full Core8 command:

```text
Test Summary: | Pass  Broken  Total       Time
Core 8        |   47       5     52  111m08.4s
Testing SciMLSensitivity tests passed
```

```text
$ GROUP=QA julia +release --project=. -e 'using Pkg; Pkg.test()'
Test Summary:     | Pass  Fail  Error  Total     Time
Quality Assurance |   17     1      2     20  6m29.3s
```

The QA failure was Aqua's persistent-task helper not creating `done.log` under load. The two errors were existing Mooncake-extension QA defects: three stale ChainRulesCore imports and four non-owner `DiffEqBase.AbstractDEProblem` accesses. All are outside this one-line Core8 test change and reproduced independently; none were suppressed.

```text
$ julia +release -m Runic --check test/Core8/mtk.jl
# exit 0

$ typos test/Core8/mtk.jl
# exit 0

$ git diff --check
# exit 0
```

No package behavior, public API, documentation, or dependency changed. GPU and other test groups were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a04-70ae-77a0-ba1b-ec7a1ed9ef47
