### PR TITLE
Use owner APIs in Mooncake extension

### DIFF
--- a/ext/SciMLSensitivityMooncakeExt.jl
+++ b/ext/SciMLSensitivityMooncakeExt.jl
@@ -16,7 +16,7 @@ using SciMLSensitivity: SciMLBase, SciMLStructures, canonicalize, Tunable, issci
     unwrapped_f, state_values, current_time
 using SciMLSensitivity: FunctionWrappersWrappers, ODEFunction
 using SciMLBase: remake, solve
-using ChainRulesCore: NoTangent, ZeroTangent, Tangent, unthunk
+using ChainRulesCore: NoTangent
 using Accessors: @reset
 
 # Mirrors `Mooncake.__call_rule` (src/utils.jl) instead of depending on it directly: that's
@@ -303,7 +303,7 @@ end
 
 function rrule!!(
         f::CoDual{typeof(DiffEqBase.solve_up)},
-        prob::CoDual{<:DiffEqBase.AbstractDEProblem},
+        prob::CoDual{<:SciMLBase.AbstractDEProblem},
         sensealg::CoDual{<:MooncakeAdjoint},
         u0::CoDual, p::CoDual, alg_and_rest::CoDual...,
     )
@@ -333,7 +333,7 @@ function rrule!!(
         ::CoDual{typeof(Core.kwcall)},
         kwargs::CoDual{<:NamedTuple},
         f::CoDual{typeof(DiffEqBase.solve_up)},
-        prob::CoDual{<:DiffEqBase.AbstractDEProblem},
+        prob::CoDual{<:SciMLBase.AbstractDEProblem},
         sensealg::CoDual{<:MooncakeAdjoint},
         u0::CoDual, p::CoDual, alg_and_rest::CoDual...,
     )
@@ -474,7 +474,7 @@ end
 
 function rrule!!(
         ::CoDual{typeof(DiffEqBase.solve_up)},
-        ::CoDual{<:DiffEqBase.AbstractDEProblem},
+        ::CoDual{<:SciMLBase.AbstractDEProblem},
         sensealg::CoDual{<:_MooncakeUnsupportedAnotherADSensealg},
         ::CoDual, ::CoDual, ::CoDual...,
     )
@@ -485,7 +485,7 @@ function rrule!!(
         ::CoDual{typeof(Core.kwcall)},
         ::CoDual{<:NamedTuple},
         ::CoDual{typeof(DiffEqBase.solve_up)},
-        ::CoDual{<:DiffEqBase.AbstractDEProblem},
+        ::CoDual{<:SciMLBase.AbstractDEProblem},
         sensealg::CoDual{<:_MooncakeUnsupportedAnotherADSensealg},
         ::CoDual, ::CoDual, ::CoDual...,
     )


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

The Mooncake extension retained three ChainRulesCore imports after their last uses were removed, and it qualified `AbstractDEProblem` through DiffEqBase even though SciMLBase owns that public API. The extension now imports only the ChainRulesCore name it uses and qualifies `AbstractDEProblem` through the public SciMLBase owner module.

Both QA regressions were introduced by https://github.com/SciML/SciMLSensitivity.jl/commit/f2c4fb31834f680e422f8eab5d9ca0020e07d390 from https://github.com/SciML/SciMLSensitivity.jl/pull/1571.

## Verification

Failing before on unmodified SciMLSensitivity master (`1bb497ff2af6fa8899c3af0c50848f6e6a14a437`):

```text
$ GROUP=QA julia +release --project=. -e 'using Pkg; Pkg.test()'
StaleImportsException
Module `SciMLSensitivityMooncakeExt` has stale (unused) explicit imports for:
* `Tangent`
* `ZeroTangent`
* `unthunk`

QualifiedAccessesFromNonOwnerException
`AbstractDEProblem` has owner `SciMLBase` but it was accessed from `DiffEqBase`

Quality Assurance | 17 pass, 1 fail, 2 errors, 20 total
```

The unrelated single failure above was Aqua's persistent-task check observing a missing `done.log` while multiple package tests were contending on this host. No test was suppressed; the isolated fixed rerun is below.

```text
$ GROUP=QA julia +release --project=. -e 'using Pkg; Pkg.test()'
Test Summary:     | Pass  Total     Time
Quality Assurance |   20     20  2m39.6s
Testing SciMLSensitivity tests passed

$ GROUP=Core1 julia +release --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Error  Broken  Total      Time
Core1         |  211      1       6    218  92m53.7s
  SciMLStructures Interface | 14 pass, 1 error, 15 total
EnzymeRuntimeActivityError: Detected potential need for runtime activity.
  @ test/Core1/scimlstructures_interface.jl:154
RNG: Random.Xoshiro(0xb7bb414ff483104b, 0x171c97c14663362c,
                   0x27b319951673f520, 0x9d5a26d15006711b,
                   0x11079836681d942c)
ERROR: Package SciMLSensitivity errored during testing
```

The full Core1 group did not pass. Its sole error is an Enzyme runtime-activity failure in the unchanged SciMLStructures-interface test; it does not exercise the stale imports or the four `AbstractDEProblem` dispatch annotations changed here. The exact log and RNG seed were preserved for a separate clean-master investigation, and the failure was not suppressed.

```text
$ /home/crackauc/.juliaup/bin/julia +release -m Runic --check ext/SciMLSensitivityMooncakeExt.jl
# exit 0

$ typos ext/SciMLSensitivityMooncakeExt.jl
# exit 0

$ git diff --check
# exit 0
```

No public API, documentation, or dependency changed. GPU and other test groups were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a04-70ae-77a0-ba1b-ec7a1ed9ef47
