### PR TITLE
Fix hyphenations flagged by the typos CI check

### DIFF
--- a/src/optimization_adjoint.jl
+++ b/src/optimization_adjoint.jl
@@ -68,9 +68,9 @@ _opt_eval_mat(fn, _, _, x, _, ::Val{false}, ::Val{false}) = fn(x)
 
 # Element type for an in-place derivative buffer that must hold values combining `S`- and `T`-typed
 # numbers — Float64 normally, or a ForwardDiff.Dual / ReverseDiff.TrackedReal when the outer VJP
-# (residual, ∂/∂q) or the inner AD (Lxx, ∂/∂x) pushes an AD type through. Public, inferrable
+# (residual, ∂/∂q) or the inner AD (Lxx, ∂/∂x) pushes an AD type through. Public, inferable
 # equivalent of `Base.promote_op(+, S, T)`: evaluating the actual `+` reproduces ForwardDiff's
-# @define_binary_dual_op nesting (e.g. Dual-over-TrackedReal, which `promote_type` mis-orders) and
+# @define_binary_dual_op nesting (e.g. Dual-over-TrackedReal, which `promote_type` misorders) and
 # folds to a compile-time `Type` constant, while staying within the public API. Both `S` and `T` are
 # promoted so we pick up the dual whether it rides in on the state (Lxx) or the parameters (residual).
 _opt_bufel(S::Type, T::Type) = typeof(oneunit(S) + oneunit(T))
@@ -192,7 +192,7 @@ end
 #     ZygoteVJP (can't order nested ForwardDiff tags); the forward-mode `Bool`/ForwardDiff path
 #     nests fine. ReverseDiffVJP/MooncakeVJP nest fine *unconstrained*, but on a constrained
 #     problem they run a reverse tape over the inner forward-mode `cons_j`, whose nested-AD output
-#     buffer OptimizationBase currently mis-types (its `_cons_out_eltype` uses `promote_type`,
+#     buffer OptimizationBase currently mistypes (its `_cons_out_eltype` uses `promote_type`,
 #     which orders nested AD element types backwards — Dual-over-TrackedReal ↔ TrackedReal-over-Dual).
 #     So they are rejected when `has_cons`; use the forward-mode VJP (or an Enzyme function) instead.
 function _opt_validate_outer_vjp(autojacvec, adtype, has_cons)
@@ -312,7 +312,7 @@ end
 #         :: :enzyme_backend — EnzymeVJP over a non-Enzyme function (Enzyme can't nest over ForwardDiff)
 #         :: :enzyme_inner   — an Enzyme-built function needs EnzymeVJP (others can't nest over Enzyme)
 #         :: :reverse_constrained — a reverse-mode outer VJP (ReverseDiffVJP/MooncakeVJP) on a
-#                                   constrained problem (mis-typed nested-AD buffer in cons_j)
+#                                   constrained problem (mistyped nested-AD buffer in cons_j)
 #   adtype = the OptimizationFunction's ADType; autojacvec = the chosen outer VJP.
 struct OptimizationAdjointUnsupportedVJPError <: Exception
     kind::Symbol
@@ -345,7 +345,7 @@ function Base.showerror(io::IO, e::OptimizationAdjointUnsupportedVJPError)
             "OptimizationAdjoint does not support reverse-mode outer VJPs " *
                 "(`autojacvec = $(e.autojacvec)`) for constrained problems: the parameter VJP nests a " *
                 "reverse-mode tape over the forward-mode constraint Jacobian, and OptimizationBase's " *
-                "`cons_j` currently mis-types the resulting nested-AD buffer (a known limitation). Use the " *
+                "`cons_j` currently mistypes the resulting nested-AD buffer (a known limitation). Use the " *
                 "default forward-mode VJP (`autojacvec = true`), or build the OptimizationFunction with " *
                 "`AutoEnzyme()` and pass `autojacvec = EnzymeVJP()`."
         )

--- a/test/Core6/optimization_adjoint.jl
+++ b/test/Core6/optimization_adjoint.jl
@@ -233,7 +233,7 @@ end
             @test dp2[1] ≈ 0.5 rtol = 1.0e-4   # du2*/dp[1]
 
             # Reverse-mode outer VJPs nest a reverse tape over the forward-mode cons_j, whose
-            # nested-AD buffer OptimizationBase currently mis-types. Rejected with a clear error
+            # nested-AD buffer OptimizationBase currently mistypes. Rejected with a clear error
             # for constrained problems (rather than a deep AD crash); allowed unconstrained.
             @test_throws SciMLSensitivity.OptimizationAdjointUnsupportedVJPError adjoint_sensitivities(
                 opt_sol, nothing;


### PR DESCRIPTION
## What changed and why

`typos` flags the split words in `mis-types`/`mis-typed`/`mis-orders` and the `inferrable` spelling in `src/optimization_adjoint.jl` (and one test comment), failing the Spell Check job on every PR — e.g. https://github.com/SciML/SciMLSensitivity.jl/actions/runs/32905269515 on the unrelated https://github.com/SciML/SciMLSensitivity.jl/pull/1611. Comment and error-message wording only; no behavior change. Mechanical change, ships alone.

## Verification

`typos` on the repo root: exit 0, no findings (was 6 errors). Runic `--check` on both changed files: exit 0. No tests added — no executable behavior changed; the one reworded error message is asserted in tests by exception type (`OptimizationAdjointUnsupportedVJPError`), not by message text.

Not verified: nothing — this diff has no runtime surface.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4CWNHT9we9k1tFL4hSXrM