### PR TITLE
Correct release version to 7.119.0 (new OptimizationAdjoint API)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLSensitivity"
 uuid = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
-version = "7.118.2"
+version = "7.119.0"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
## What changed and why

`Project.toml` declares `7.118.2`, a patch bump over the registered `7.118.1`. The unreleased delta on master is not a patch:

- `src/optimization_adjoint.jl` — new file, **+812 lines**
- `src/sensitivity_algorithms.jl` — **+149**
- `src/concrete_solve.jl` — +171/-11
- `src/SciMLSensitivity.jl` — adds `OptimizationAdjoint` to the `export` list

Adding a new **exported** sensitivity algorithm (`OptimizationAdjoint`, alongside the existing `UnconstrainedOptimizationAdjoint`) is new public API, which SemVer requires be a **minor** bump. Registering it as `7.118.2` would ship a feature under a patch version.

This PR only changes the version declaration: `7.118.2` → `7.119.0`. No code changes.

Carried commits since 7.118.1:
- Preserve despecialized parameters in adjoint VJPs (#1601)
- OptimizationAdjoint for constrained optimization solution sensitivities (#1444)
- Use owner APIs in Mooncake extension (#1613)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R