### PR TITLE
Import Optimisers algorithms from their owner

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -102,6 +102,7 @@ SCCNonlinearSolve = "1.12.1"
 Optimization = "5.5.1"
 OptimizationNLopt = "0.3.16"
 OptimizationOptimisers = "0.3.21"
+Optimisers = "0.4"
 OrdinaryDiffEq = "7"
 OrdinaryDiffEqBDF = "2.3"
 OrdinaryDiffEqCore = "4.15.1"
@@ -160,6 +161,7 @@ NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 Optimization = "7f7a1694-90dd-40f0-9382-eb1efda571ba"
 OptimizationNLopt = "4e6fcdb7-1186-4e1f-a706-475e75c168bb"
 OptimizationOptimisers = "42dfb2eb-d2b4-4451-abcd-913932933ac1"
+Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 OrdinaryDiffEqFIRK = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 OrdinaryDiffEqFunctionMap = "d3585ca7-f5d3-4ba6-8057-292ed1abd90f"
@@ -182,4 +184,4 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AlgebraicMultigrid", "Aqua", "Calculus", "ComponentArrays", "DelayDiffEq", "DifferentiationInterface", "Distributed", "ExplicitImports", "Logging", "Lux", "ModelingToolkit", "Mooncake", "NLsolve", "NonlinearSolve", "Optimization", "OptimizationOptimisers", "OptimizationNLopt", "OrdinaryDiffEq", "OrdinaryDiffEqBDF", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqFunctionMap", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqStabilizedRK", "Reactant", "SCCNonlinearSolve", "SafeTestsets", "SciMLTesting", "SparseArrays", "StableRNGs", "SteadyStateDiffEq", "StochasticDiffEq", "Sundials", "Symbolics", "Test"]
+test = ["AlgebraicMultigrid", "Aqua", "Calculus", "ComponentArrays", "DelayDiffEq", "DifferentiationInterface", "Distributed", "ExplicitImports", "Logging", "Lux", "ModelingToolkit", "Mooncake", "NLsolve", "NonlinearSolve", "Optimization", "OptimizationOptimisers", "OptimizationNLopt", "Optimisers", "OrdinaryDiffEq", "OrdinaryDiffEqBDF", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqFunctionMap", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqStabilizedRK", "Reactant", "SCCNonlinearSolve", "SafeTestsets", "SciMLTesting", "SparseArrays", "StableRNGs", "SteadyStateDiffEq", "StochasticDiffEq", "Sundials", "Symbolics", "Test"]

--- a/test/Core4/distributed.jl
+++ b/test/Core4/distributed.jl
@@ -11,6 +11,7 @@ if VERSION >= v"1.12"
     end
 else
     using Optimization, OptimizationOptimisers
+    using Optimisers: Adam
     using ADTypes
 
     addprocs(2)

--- a/test/Core4/ensembles.jl
+++ b/test/Core4/ensembles.jl
@@ -1,4 +1,5 @@
 using SciMLSensitivity, OrdinaryDiffEq, Optimization, OptimizationOptimisers, Test
+using Optimisers: Adam
 using ADTypes
 using SciMLBase: EnsembleSerial, EnsembleThreads
 

--- a/test/Core4/gdp_regression_test.jl
+++ b/test/Core4/gdp_regression_test.jl
@@ -1,6 +1,7 @@
 using SciMLSensitivity,
     OrdinaryDiffEq, LinearAlgebra, Test, Zygote, Optimization,
     OptimizationOptimisers
+using Optimisers: Adam
 
 GDP = [
     11394358246872.6,

--- a/test/Core4/layers.jl
+++ b/test/Core4/layers.jl
@@ -1,4 +1,5 @@
 using SciMLSensitivity, OrdinaryDiffEq, Test, Optimization, OptimizationOptimisers
+using Optimisers: Adam
 using ADTypes
 using Zygote
 const AD_BACKEND = AutoZygote()

--- a/test/Core4/sde_neural.jl
+++ b/test/Core4/sde_neural.jl
@@ -2,6 +2,7 @@ using SciMLSensitivity, Lux, ComponentArrays, LinearAlgebra, DiffEqNoiseProcess,
 using StochasticDiffEq, Statistics, SciMLSensitivity
 using DiffEqBase.EnsembleAnalysis
 using Optimization, OptimizationOptimisers
+using Optimisers: Adam
 
 using Random
 Random.seed!(238248735)

--- a/test/Core5/HybridNODE.jl
+++ b/test/Core5/HybridNODE.jl
@@ -1,5 +1,6 @@
 using SciMLSensitivity, OrdinaryDiffEq, DiffEqCallbacks, Lux, ComponentArrays
 using Optimization, OptimizationOptimisers, Random, Test, Zygote
+using Optimisers: Adam
 
 function test_hybridNODE(sensealg)
     Random.seed!(12345)

--- a/test/Core5/callback_reversediff.jl
+++ b/test/Core5/callback_reversediff.jl
@@ -1,5 +1,6 @@
 using OrdinaryDiffEq, Lux, ComponentArrays, SciMLSensitivity, DiffEqCallbacks, Test
 using Optimization, OptimizationOptimisers, Zygote
+using Optimisers: Adam
 using Random
 
 Random.seed!(1234)

--- a/test/Core5/complex_no_u.jl
+++ b/test/Core5/complex_no_u.jl
@@ -1,5 +1,6 @@
 using OrdinaryDiffEq, ComponentArrays, Random,
     SciMLSensitivity, LinearAlgebra, Optimization, OptimizationOptimisers, Lux
+using Optimisers: Adam
 nn = Chain(Dense(1, 16), Dense(16, 16, tanh), Dense(16, 2)) |> f64
 ps, st = Lux.setup(Random.default_rng(), nn)
 ps = ComponentArray(ps)

--- a/test/Core5/forwarddiffsensitivity_sparsity_components.jl
+++ b/test/Core5/forwarddiffsensitivity_sparsity_components.jl
@@ -1,6 +1,7 @@
 using OrdinaryDiffEq, SciMLSensitivity, ADTypes
 using OrdinaryDiffEqRosenbrock: Rodas4P
 using ComponentArrays, LinearAlgebra, Optimization, OptimizationOptimisers, Test
+using Optimisers: Adam
 
 const nknots = 10
 const h = 1.0 / (nknots + 1)

--- a/test/Core5/hybrid_de.jl
+++ b/test/Core5/hybrid_de.jl
@@ -1,5 +1,6 @@
 using Lux, ComponentArrays, SciMLSensitivity, DiffEqCallbacks, OrdinaryDiffEq, Test # , Plots
 using Optimization, OptimizationOptimisers, Zygote, Random
+using Optimisers: Adam
 
 u0 = Float32[2.0; 0.0]
 datasize = 100

--- a/test/Core5/size_handling_adjoint.jl
+++ b/test/Core5/size_handling_adjoint.jl
@@ -1,6 +1,7 @@
 using SciMLSensitivity, Zygote, OrdinaryDiffEq, Test, Reactant
 using OrdinaryDiffEqLowOrderRK: Midpoint
 using Optimization, OptimizationOptimisers
+using Optimisers: Adam
 
 p = [1.5 1.0; 3.0 1.0]
 function lotka_volterra(du, u, p, t)

--- a/test/Core6/optimization_adjoint.jl
+++ b/test/Core6/optimization_adjoint.jl
@@ -1,5 +1,6 @@
 using Test, LinearAlgebra
 using SciMLSensitivity, Optimization, OptimizationOptimisers, OptimizationNLopt, SciMLBase
+using Optimisers: Descent
 using Mooncake, ForwardDiff, FiniteDiff
 using SciMLSensitivity: MooncakeVJP, alg_autodiff, diff_type
 


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## What changed

OptimizationOptimisers 0.3.22 stopped re-exporting algorithm types from Optimisers, but SciMLSensitivity's Core4–Core6 tests still constructed `Adam` and `Descent` as unqualified names. This adds Optimisers as an MIT-licensed, test-only dependency and imports each algorithm explicitly from its documented public owner API. Production code and the SciMLSensitivity public API are unchanged.

## Regression boundary

- OptimizationOptimisers 0.3.21: `using OptimizationOptimisers; Adam(0.1); Descent(0.01)` exits 0.
- OptimizationOptimisers 0.3.22: the same bare constructions exit 1 with `UndefVarError`, and Julia identifies Optimisers as the owner.
- `using Optimisers: Adam, Descent` with OptimizationOptimisers 0.3.22 exits 0.

The boundary is https://github.com/SciML/Optimization.jl/commit/0c726c0cf0b2f4c150b26ca03c4117e8a35434af, which replaced the Optimisers re-export with a normal import.

## Failing before / passing after

On pristine SciMLSensitivity master `5174411526fdb52e859c66603b66afa230eae9f9`:

```text
GROUP=Core4 ... Pkg.test()
Core 4 | 8 passed, 8 errored, 2 broken
ERROR: ... Adam not defined ...
```

With this change:

```text
GROUP=Core4 ... Pkg.test()
Core 4 | 16 passed, 2 broken
Testing SciMLSensitivity tests passed
```

The pristine Core5 group produced 20 `Adam` errors across Size Handling, Callback-ReverseDiff, Hybrid DE, HybridNODE, ForwardDiff Sparsity, and Complex No-u. With this change, Core5 passes 42/42 on Julia release and Julia 1.11. The pristine run also exposed an unrelated clean-master `@test_nowarn` failure in Parameter Handling under one fresh release resolution; no test was weakened or suppressed here.

The pristine Core6 group failed with four `Descent` errors:

```text
Core 6 | 225 passed, 4 errored, 4 broken
ERROR: ... Descent not defined ...
```

With this change:

```text
Core 6 | 238 passed, 4 broken
Testing SciMLSensitivity tests passed
```

The original CI failures are visible in the Core4 jobs for [current](https://github.com/SciML/SciMLSensitivity.jl/actions/runs/32925822802/job/98048429293), [Julia 1.11](https://github.com/SciML/SciMLSensitivity.jl/actions/runs/32925822802/job/98048429108), and [LTS](https://github.com/SciML/SciMLSensitivity.jl/actions/runs/32925822802/job/98048429141), and the Core5 jobs for [current](https://github.com/SciML/SciMLSensitivity.jl/actions/runs/32925822802/job/98048429639), [Julia 1.11](https://github.com/SciML/SciMLSensitivity.jl/actions/runs/32925822802/job/98048429159), and [LTS](https://github.com/SciML/SciMLSensitivity.jl/actions/runs/32925822802/job/98048429388).

## Verification

- `GROUP=Core4 julia +release --project=. -e 'using Pkg; Pkg.test()'`: 16 passed, 2 pre-existing broken, 18 total in 10m46.4s.
- `GROUP=Core4 julia +1.11 --project=. -e 'using Pkg; Pkg.test()'`: 17/17 in 40m22.4s.
- `GROUP=Core4 julia +lts --project=. -e 'using Pkg; Pkg.test()'`: 17/17 in 38m43.0s.
- `GROUP=Core5 julia +release --project=. -e 'using Pkg; Pkg.test()'`: 42/42 in 34m29.7s.
- `GROUP=Core5 julia +1.11 --project=. -e 'using Pkg; Pkg.test()'`: 42/42 in 36m30.8s.
- `GROUP=Core5 julia +lts --project=. -e 'using Pkg; Pkg.test()'`: 42/42 in 26m29.4s on Julia 1.10.12.
- `GROUP=Core6 julia +release --project=. -e 'using Pkg; Pkg.test()'`: 238 passed, 4 pre-existing broken, 242 total in 48m06.6s.
- `GROUP=QA julia +release --project=. -e 'using Pkg; Pkg.test()'`: unchanged warm retry passed 20/20 in 2m36.4s, and detached clean upstream master passed 20/20 in 2m58.3s with the same warmed isolated depot. The first fresh-depot run passed 19/20 substantive checks but hit an Aqua wrapper-precompile transient (`done.log` was not created after the subprocess exited); no test or QA configuration was changed before either passing run.
- `julia +release --project=<Runic environment> -m Runic --check .`: exit 0 (Runic 1.9.0).
- `git diff -U0 upstream/master...HEAD | typos -`: exit 0.
- `git diff --check upstream/master...HEAD`: exit 0.

Docs were not built because this changes only test dependencies and test imports, with no docs, docstrings, production code, or public API. GPU, downstream, and unrelated test groups were not run locally.

Related failure report: https://github.com/SciML/SciMLSensitivity.jl/pull/1612

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a04-70ae-77a0-ba1b-ec7a1ed9ef47
