### PR TITLE
Use Enzyme runtime activity for mixed-precision adjoints

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -47,7 +47,9 @@ function inplace_vjp(prob, u0, p, verbose, repack)
     # Get time value - NonlinearProblems don't have tspan
     t0 = prob isa AbstractNonlinearProblem ? nothing : prob.tspan[1]
 
-    ez = try
+    # Mixed-precision adjoints can require runtime activity even when this probe succeeds.
+    same_eltype = eltype(u0) === eltype(p)
+    ez = same_eltype && try
         f = unwrapped_f(prob.f)
 
         # Skip Enzyme autodiff for NonlinearProblems since they don't have tspan

--- a/test/Core3/automatic_sensealg_choice.jl
+++ b/test/Core3/automatic_sensealg_choice.jl
@@ -1,4 +1,4 @@
-using Lux, ComponentArrays, OrdinaryDiffEq, SciMLSensitivity, Random, Test
+using Lux, ComponentArrays, Enzyme, OrdinaryDiffEq, SciMLSensitivity, Random, Test
 using SciMLStructures
 
 # Only import Zygote on Julia <= 1.11
@@ -30,6 +30,16 @@ sensealg = SciMLSensitivity.automatic_sensealg_choice(prob, x0, θ, true, repack
 
 @test sensealg isa GaussAdjoint
 @test sensealg.autojacvec isa EnzymeVJP
+@test sensealg.autojacvec.mode == Enzyme.Reverse
+
+mixed_x0 = Float64.(x0)
+mixed_prob = ODEProblem(dxdt_, mixed_x0, tspan, θ)
+mixed_sensealg = SciMLSensitivity.automatic_sensealg_choice(
+    mixed_prob, mixed_x0, θ, true, repack
+)
+@test mixed_sensealg isa GaussAdjoint
+@test mixed_sensealg.autojacvec isa EnzymeVJP
+@test mixed_sensealg.autojacvec.mode == Enzyme.set_runtime_activity(Enzyme.Reverse)
 
 # Regression test: an in-place RHS that is a struct holding `SparseMatrixCSC` fields must
 # still select EnzymeVJP. The availability probe used to capture the RHS in a closure, which


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

`automatic_sensealg_choice` can pass Enzyme's static activity probe for a mixed-precision state/parameter problem even though the actual adjoint later requires runtime activity. Mixed element types now select the existing runtime-activity mode; same-element-type problems retain static Enzyme reverse mode.

The regression imports Enzyme from its owning module and checks both branches of that rule.

## Failure before

The new assertion discriminates the bug on a clean upstream worktree:

```text
GROUP=Core3 julia +release --project -e 'using Pkg; Pkg.test()'

automatic sensealg choice | 8 pass, 1 fail
Evaluated: ReverseMode{... runtimeActivity = false ...} ==
           ReverseMode{... runtimeActivity = true ...}
Core 3 | 317 pass, 1 fail, 6 broken, 324 total, 122m33.8s
```

This is the same unsafe selection behind the previously observed `EnzymeRuntimeActivityError` in the SciMLStructures interface test.

## Passing after

After rebasing over current upstream `master`:

```text
GROUP=Core3 julia +release --project -e 'using Pkg; Pkg.test()'
Core 3 | 318 pass, 6 broken, 324 total, 124m08.9s
Testing SciMLSensitivity tests passed

GROUP=QA julia +release --project -e 'using Pkg; Pkg.test()'
Quality Assurance | 20 pass, 20 total, 2m06.8s
Testing SciMLSensitivity tests passed

julia +release -m Runic --check src/concrete_solve.jl test/Core3/automatic_sensealg_choice.jl
# exit 0

git diff upstream/master...HEAD | typos -
# exit 0

git diff --check upstream/master...HEAD
# exit 0
```

## CI failure classification

- The normal QA job failed only Aqua's persistent-task check because precompilation exited without creating its temporary `done.log`: 19 passed, 1 failed. The exact post-rebase local QA command above passes 20/20; no test is disabled or silenced.
- The normal Core8 jobs on Julia 1.11 and lts each reach `45 passed, 1 errored, 5 broken`. Exact downgraded Core1 on clean master reaches `261 passed, 1 errored, 5 broken` in 91m29.8s and first fails in Mooncake's `frule!!` for a FunctionWrapper tangent. PR https://github.com/SciML/SciMLSensitivity.jl/pull/1625 raises FunctionWrappersWrappers to 1.13.0 and removes that error; exact Core1 then reaches the same aggregate in 91m02.9s but exposes an old OrdinaryDiffEqCore/Mooncake PhiC/Upsilon failure in `_ode_initdt_iip`. Focused draft https://github.com/SciML/SciMLSensitivity.jl/pull/1626 raises OrdinaryDiffEqCore to the first release containing its two-mode Mooncake primitive: the reduced HVP exits 1 on 4.13.0 and exits 0 on 4.15.1; QA passes 20/20. Neither dependency error is caused by this Core3 change.

## Scope and unverified paths

Runtime activity can be slower than static activity, so the change is limited to mixed state/parameter element types. Same-type selection is unchanged and covered by the regression. No dependency, public API, docstring, or documentation changes are included; a docs build was therefore not run. GPU and downstream groups were not run locally.

The initially suspected ComponentArrays boundary was ruled out: clean controls with ComponentArrays 0.15.44 and 0.15.46 both reproduced the runtime-activity error. A standalone no-SciML Enzyme/Lux/ComponentArrays reproducer did not fail, so no upstream Enzyme issue was filed.

## Links

- Triggering validation PR: https://github.com/SciML/SciMLSensitivity.jl/pull/1613
- Downgrade FunctionWrappersWrappers floor: https://github.com/SciML/SciMLSensitivity.jl/pull/1625\n- Downgrade OrdinaryDiffEqCore floor: https://github.com/SciML/SciMLSensitivity.jl/pull/1626\n- Full-group FunctionWrappersWrappers evidence: https://github.com/SciML/SciMLSensitivity.jl/pull/1625#issuecomment-5446521471
- Existing runtime-activity fallback: https://github.com/SciML/SciMLSensitivity.jl/pull/1304
- Static/runtime performance prior art: https://github.com/SciML/SciMLSensitivity.jl/pull/1527
- QA persistent-task failure: https://github.com/SciML/SciMLSensitivity.jl/actions/runs/33111451636/job/98666780324
- Downgrade Core1 failure: https://github.com/SciML/SciMLSensitivity.jl/actions/runs/33111450922/job/98655038067

🤖 Generated with Codex CLI 0.150.1 (model: unknown; session: local session ID 01a0441e-3d2f-7170-ab6e-58ef72975a9f).
