### PR TITLE
Probe parameter-only Enzyme VJP activity

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -28,11 +28,28 @@ const STACKTRACE_WITH_VJPWARN = Ref(false)
 # `SparseMatrixCSC` field — as closure data, which Enzyme cannot prove read-only, so the
 # probe spuriously throws `EnzymeMutabilityException` and falls back to ReverseDiff even
 # though EnzymeVJP works for such RHS. `f` is given a shadow (`Duplicated`, not `Const`) to
-# match how `_vecjacobian!` actually invokes Enzyme on the in-place RHS
+# match how the state and parameter VJPs invoke Enzyme on the in-place RHS
 # (`Duplicated(SciMLBase.Void(f), …)`), so an `f` that mutates internal caches or embeds
-# parameters is probed the same way it is used.
+# parameters is probed with the same activity patterns it will use.
 function _enzyme_vjp_probe(f, repack, out, u, _p, t)
     f(out, u, repack(_p), t)
+    return nothing
+end
+
+function _probe_enzyme_vjp(mode, f, repack, u, p, t)
+    Enzyme.autodiff(
+        mode, _enzyme_vjp_probe,
+        Enzyme.Duplicated(f, Enzyme.make_zero(f)), Enzyme.Const(repack),
+        Enzyme.Duplicated(zero(u), copy(u)),
+        Enzyme.Duplicated(copy(u), zero(u)), Enzyme.Duplicated(copy(p), zero(p)),
+        Enzyme.Const(t)
+    )
+    Enzyme.autodiff(
+        mode, _enzyme_vjp_probe,
+        Enzyme.Duplicated(f, Enzyme.make_zero(f)), Enzyme.Const(repack),
+        Enzyme.Duplicated(zero(u), copy(u)),
+        Enzyme.Const(copy(u)), Enzyme.Duplicated(copy(p), zero(p)), Enzyme.Const(t)
+    )
     return nothing
 end
 
@@ -41,7 +58,6 @@ function inplace_vjp(prob, u0, p, verbose, repack)
     # residuals `f(res, du, u, p, t)`; the DAE residual vjp machinery
     # (the SundialsAdjoint/IDA path) is ReverseDiff-tape based.
     prob isa SciMLBase.AbstractDAEProblem && return ReverseDiffVJP()
-    du = zero(u0)
     # Get verbosity for sensitivity VJP choice warnings
     _verbose = _get_sensitivity_vjp_verbose(verbose)
     # Get time value - NonlinearProblems don't have tspan
@@ -54,13 +70,7 @@ function inplace_vjp(prob, u0, p, verbose, repack)
         if prob isa AbstractNonlinearProblem
             false
         else
-            Enzyme.autodiff(
-                Enzyme.Reverse, _enzyme_vjp_probe,
-                Enzyme.Duplicated(f, Enzyme.make_zero(f)), Enzyme.Const(repack),
-                Enzyme.Duplicated(du, copy(u0)),
-                Enzyme.Duplicated(copy(u0), zero(u0)), Enzyme.Duplicated(copy(p), zero(p)),
-                Enzyme.Const(t0)
-            )
+            _probe_enzyme_vjp(Enzyme.Reverse, f, repack, u0, p, t0)
             true
         end
     catch e
@@ -77,12 +87,8 @@ function inplace_vjp(prob, u0, p, verbose, repack)
         if prob isa AbstractNonlinearProblem
             false
         else
-            Enzyme.autodiff(
-                Enzyme.set_runtime_activity(Enzyme.Reverse), _enzyme_vjp_probe,
-                Enzyme.Duplicated(f, Enzyme.make_zero(f)), Enzyme.Const(repack),
-                Enzyme.Duplicated(du, copy(u0)),
-                Enzyme.Duplicated(copy(u0), zero(u0)), Enzyme.Duplicated(copy(p), zero(p)),
-                Enzyme.Const(t0)
+            _probe_enzyme_vjp(
+                Enzyme.set_runtime_activity(Enzyme.Reverse), f, repack, u0, p, t0
             )
             true
         end


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

The automatic Enzyme VJP chooser now probes both activity patterns used by adjoint code: the joint state/parameter VJP and the parameter-only VJP with a constant state. Under coverage instrumentation, a Lux RHS can compile for the first pattern with static activity but fail with `EnzymeRuntimeActivityError` for the second, causing the chooser to select an unusable static `EnzymeVJP`.

Testing the parameter-only pattern makes the existing static-first/runtime-fallback logic choose runtime activity only when it is needed. This preserves the caller-provided `repack` behavior from https://github.com/SciML/SciMLSensitivity.jl/pull/1606 and continues to select static activity outside the coverage-sensitive case.

## Verification

### Failing before

On commit `1add079900d48373f1ab6825fae84f0cff742319`, from the `Pkg.test` environment generated for Julia 1.12.7:

```sh
cd /home/crackauc/sandbox/tmp_20260825_180339_53321/ordinarydiffeq-stoch-master-downstream
/home/crackauc/.juliaup/bin/julia +1 -C native -g1 --color=yes \
  --threads=1,1 \
  --code-coverage=@/home/crackauc/sandbox/tmp_20260825_180339_53321/ordinarydiffeq-stoch-master-downstream/downstream \
  --check-bounds=yes --warn-overwrite=yes --depwarn=error --inline=yes \
  --startup-file=no --track-allocation=none \
  --project=/home/crackauc/tmp/jl_XyO5D0 \
  -e 'lines = readlines("downstream/test/Core1/scimlstructures_interface.jl"); include_string(Main, join(lines[1:154], "\n"), "scimlstructures_interface.jl")'
```

This exited 1 at `scimlstructures_interface.jl:154` with:

```text
EnzymeRuntimeActivityError
@test !iszero(Zygote.gradient(run_diff, initialize())[1].ps)
```

The same failure is present on clean master CI:

- SciMLSensitivity: https://github.com/SciML/SciMLSensitivity.jl/actions/runs/33132229607/job/98724210160
- OrdinaryDiffEq downstream Core1: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33162274637/job/98821542909

### Passing after

The identical targeted command on this branch exited 0. An explicit `Enzyme.set_runtime_activity(Enzyme.Reverse)` control under the same coverage flags also exited 0.

A non-coverage chooser control exited 0 and reported:

```text
sensealg = GaussAdjoint{0, true, Val{:central}, EnzymeVJP{ReverseMode{false, false, false, FFIABI, false, false}}, Val{true}}(...)
```

This confirms static activity remains selected when the parameter-only probe supports it.

Full relevant and QA groups:

```sh
GROUP=Core1 julia +1 --project=. -e 'using Pkg; Pkg.test(coverage = true)'
```

```text
Test Summary: | Pass  Broken  Total      Time
Core1         |  212       6    218  100m14.3s
Testing SciMLSensitivity tests passed
```

```sh
GROUP=QA julia +1 --project=. -e 'using Pkg; Pkg.test()'
```

```text
Test Summary:     | Pass  Total     Time
Quality Assurance |   20     20  3m04.5s
Testing SciMLSensitivity tests passed
```

Formatting and spelling:

```sh
julia +1 -m Runic --check --diff src/concrete_solve.jl
typos src/concrete_solve.jl
git diff --check
```

All exited 0 with no output.

I did not run docs because this changes no public API, docstring, or documentation. GPU, downstream, and the other Core groups were not run locally.

The main review judgment is the extra availability-probe compilation cost in exchange for matching both activity patterns that the selected VJP must support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03caf-aae8-74c3-9a79-53b836434858
