### PR TITLE
Support structured parameters and untracked problem callbacks in callback adjoints

### DIFF
--- a/docs/src/manual/differential_equation_sensitivities.md
+++ b/docs/src/manual/differential_equation_sensitivities.md
@@ -179,29 +179,13 @@ and DDEs. The continuous adjoint sensitivities `BacksolveAdjoint`, `Interpolatin
 the event terminates the time evolution and several states are saved. Currently,
 the continuous adjoint sensitivities do not support multiple events per time point.
 
-#### Structured parameters and events
-
-Events are supported for problems whose parameter object is a
-[SciMLStructure](https://github.com/SciML/SciMLStructures.jl) rather than a plain
-vector — most notably the parameter object of a
-[ModelingToolkit.jl](https://docs.sciml.ai/ModelingToolkit/stable/) system with
-`continuous_events` or `discrete_events`. The gradient is taken with respect to
-the tunable portion of the parameters, and an affect that assigns to a parameter
-is handled as long as the parameter object is a mutable SciMLStructure.
-
 #### Events with `adjoint_sensitivities`
 
 The adjoint of a hybrid system needs the event times and the state and parameter
 values just before each event. Differentiating through `solve` records them
-automatically:
-
-```julia
-Zygote.gradient(u0 -> loss(solve(remake(prob; u0), alg; sensealg)), u0)
-```
-
-When calling [`adjoint_sensitivities`](@ref) directly, the forward solve has to be
-run with a *tracked* callback set, which `SciMLSensitivity.track_callbacks` builds
-from the callbacks of the problem:
+automatically; when calling [`adjoint_sensitivities`](@ref) directly, the forward
+solve has to be run with a *tracked* callback set, which
+`SciMLSensitivity.track_callbacks` builds from the callbacks of the problem:
 
 ```julia
 cb = SciMLSensitivity.track_callbacks(
@@ -211,11 +195,9 @@ sol = solve(_prob, alg; save_everystep = true)
 du0, dp = adjoint_sensitivities(sol, alg; t = ts, sensealg, dgdu_discrete)
 ```
 
-`adjoint_sensitivities` picks the tracked callbacks up from the problem, so
-passing `callback = cb` to it as well is optional. Handing it a solution whose
-callbacks were not tracked throws, because the events would otherwise be ignored
-silently; pass `callback` explicitly to run the adjoint without any event
-correction anyway.
+Handing `adjoint_sensitivities` a solution whose callbacks were not tracked
+throws, because the events would otherwise be ignored silently; pass `callback`
+explicitly to run the adjoint without any event correction anyway.
 
 Give the forward solve a dense (or `save_everystep = true`) solution: a
 `saveat`-only solution makes `InterpolatingAdjoint` and `GaussAdjoint` fall back

--- a/docs/src/manual/differential_equation_sensitivities.md
+++ b/docs/src/manual/differential_equation_sensitivities.md
@@ -179,6 +179,48 @@ and DDEs. The continuous adjoint sensitivities `BacksolveAdjoint`, `Interpolatin
 the event terminates the time evolution and several states are saved. Currently,
 the continuous adjoint sensitivities do not support multiple events per time point.
 
+#### Structured parameters and events
+
+Events are supported for problems whose parameter object is a
+[SciMLStructure](https://github.com/SciML/SciMLStructures.jl) rather than a plain
+vector — most notably the parameter object of a
+[ModelingToolkit.jl](https://docs.sciml.ai/ModelingToolkit/stable/) system with
+`continuous_events` or `discrete_events`. The gradient is taken with respect to
+the tunable portion of the parameters, and an affect that assigns to a parameter
+is handled as long as the parameter object is a mutable SciMLStructure.
+
+#### Events with `adjoint_sensitivities`
+
+The adjoint of a hybrid system needs the event times and the state and parameter
+values just before each event. Differentiating through `solve` records them
+automatically:
+
+```julia
+Zygote.gradient(u0 -> loss(solve(remake(prob; u0), alg; sensealg)), u0)
+```
+
+When calling [`adjoint_sensitivities`](@ref) directly, the forward solve has to be
+run with a *tracked* callback set, which `SciMLSensitivity.track_callbacks` builds
+from the callbacks of the problem:
+
+```julia
+cb = SciMLSensitivity.track_callbacks(
+    prob.kwargs[:callback], prob.tspan[1], prob.u0, prob.p, sensealg)
+_prob = remake(prob; kwargs = merge(values(prob.kwargs), (; callback = cb)))
+sol = solve(_prob, alg; save_everystep = true)
+du0, dp = adjoint_sensitivities(sol, alg; t = ts, sensealg, dgdu_discrete)
+```
+
+`adjoint_sensitivities` picks the tracked callbacks up from the problem, so
+passing `callback = cb` to it as well is optional. Handing it a solution whose
+callbacks were not tracked throws, because the events would otherwise be ignored
+silently; pass `callback` explicitly to run the adjoint without any event
+correction anyway.
+
+Give the forward solve a dense (or `save_everystep = true`) solution: a
+`saveat`-only solution makes `InterpolatingAdjoint` and `GaussAdjoint` fall back
+to checkpointing, whose event handling is currently inaccurate.
+
 ## Manual VJPs
 
 Note that when defining your differential equation, the vjp can be

--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -155,12 +155,24 @@ function (f::TrackedAffect)(integrator, event_idx = nothing)
     end
 end
 
-# A `ContinuousCallback` may be built with `affect_neg! = nothing`, in which case
-# tracking leaves the negative-crossing affect `nothing` and no event is ever
+# A `ContinuousCallback` may be built with only one of `affect!` / `affect_neg!`,
+# in which case tracking leaves the other side `nothing` and no event is ever
 # recorded for it.
 const NO_EVENT_TIMES = Float64[]
 tracked_event_times(affect) = affect.event_times
 tracked_event_times(::Nothing) = NO_EVENT_TIMES
+
+"""
+    tracked_correction(cb)
+
+The [`ImplicitCorrection`](@ref) of a tracked callback. Both sides of a
+`ContinuousCallback` share the same correction, so it is read from whichever of
+them was tracked.
+"""
+function tracked_correction(cb::ContinuousCallback)
+    return cb.affect! === nothing ? cb.affect_neg!.correction : cb.affect!.correction
+end
+tracked_correction(cb) = cb.affect!.correction
 
 is_tracked_affect(::TrackedAffect) = true
 is_tracked_affect(::Nothing) = true
@@ -182,17 +194,6 @@ function all_callbacks_tracked(cb)
     cbs = CallbackSet(cb)
     return all(is_tracked_callback, cbs.continuous_callbacks) &&
         all(is_tracked_callback, cbs.discrete_callbacks)
-end
-
-"""
-    problem_callback(prob)
-
-The callback attached to the problem itself (`prob.kwargs[:callback]`), or
-`nothing` when there is none.
-"""
-function problem_callback(prob)
-    hasproperty(prob, :kwargs) || return nothing
-    return get(prob.kwargs, :callback, nothing)
 end
 
 function is_empty_callback(cb)
@@ -235,7 +236,7 @@ correction silently.
 """
 function adjoint_callbacks(sol, callback)
     is_empty_callback(callback) || return callback
-    cb = problem_callback(sol.prob)
+    cb = get(sol.prob.kwargs, :callback, nothing)
     is_empty_callback(cb) && return callback
     all_callbacks_tracked(cb) || throw(ArgumentError(UNTRACKED_CALLBACK_MESSAGE))
     return CallbackSet(cb)
@@ -479,6 +480,15 @@ function _setup_reverse_callbacks(
     return _setup_reverse_callbacks(cb, cb.affect!, sensealg, dgdu, dgdp, loss_ref, terminated)
 end
 
+# A `ContinuousCallback` may have been tracked on the negative crossing only, in
+# which case the tracked affect to dispatch on is `affect_neg!`.
+function _setup_reverse_callbacks(
+        cb::ContinuousCallback, sensealg, dgdu, dgdp, loss_ref, terminated
+    )
+    affect = cb.affect! === nothing ? cb.affect_neg! : cb.affect!
+    return _setup_reverse_callbacks(cb, affect, sensealg, dgdu, dgdp, loss_ref, terminated)
+end
+
 function _setup_reverse_callbacks(
         cb::Union{
             ContinuousCallback, DiscreteCallback,
@@ -488,9 +498,10 @@ function _setup_reverse_callbacks(
         dgdp,
         loss_ref, terminated
     )
-    if cb isa Union{ContinuousCallback, VectorContinuousCallback} && cb.affect! !== nothing
-        cb.affect!.correction.cur_time = loss_ref # set cur_time
-        cb.affect!.correction.terminated = terminated # flag if time evolution was terminated by callback
+    if cb isa Union{ContinuousCallback, VectorContinuousCallback}
+        _correction = tracked_correction(cb)
+        _correction.cur_time = loss_ref # set cur_time
+        _correction.terminated = terminated # flag if time evolution was terminated by callback
     end
 
     dgdp !== nothing &&
@@ -519,7 +530,7 @@ function _setup_reverse_callbacks(
 
     # event times
     times = if cb isa ContinuousCallback
-        [cb.affect!.event_times; cb.affect_neg!.event_times]
+        [tracked_event_times(cb.affect!); tracked_event_times(cb.affect_neg!)]
     else
         cb.affect!.event_times
     end
@@ -567,7 +578,7 @@ function _setup_reverse_callbacks(
             # wrt dependence of event time t on parameters and initial state.
             # Must be handled here because otherwise it is unclear if continuous or
             # discrete callback was triggered.
-            (; correction) = cb.affect!
+            correction = tracked_correction(cb)
             (; dy_right, Lu_right) = correction
             # compute #f(xτ_right,p_right,τ(x₀,p))
             compute_f!(dy_right, S, y, integrator)
@@ -796,7 +807,7 @@ function get_cb_diffcaches(
     _dc = []
     vcc = cb isa VectorContinuousCallback
     cc = cb isa ContinuousCallback
-    has_affect = !isempty(cb.affect!.event_times)
+    has_affect = !isempty(tracked_event_times(cb.affect!))
     has_affect_neg = cc && !isempty(tracked_event_times(cb.affect_neg!))
     pos_negs = cc ? (true, false) : (true,)
     event_idxs = vcc ? eachindex(cb.affect!.event_times) : (nothing,)
@@ -943,12 +954,13 @@ function get_indx(cb::VectorContinuousCallback, t)
     return (searchsortedfirst(cb.affect!.event_times, t), true)
 end
 function get_indx(cb::ContinuousCallback, t)
+    pos_event_times = tracked_event_times(cb.affect!)
     neg_event_times = tracked_event_times(cb.affect_neg!)
-    return if !isempty(cb.affect!.event_times) || !isempty(neg_event_times)
-        indx = searchsortedfirst(cb.affect!.event_times, t)
+    return if !isempty(pos_event_times) || !isempty(neg_event_times)
+        indx = searchsortedfirst(pos_event_times, t)
         indx_neg = searchsortedfirst(neg_event_times, t)
-        if !isempty(cb.affect!.event_times) &&
-                cb.affect!.event_times[min(indx, length(cb.affect!.event_times))] == t
+        if !isempty(pos_event_times) &&
+                pos_event_times[min(indx, length(pos_event_times))] == t
             return indx, true
         elseif !isempty(neg_event_times) &&
                 neg_event_times[min(indx_neg, length(neg_event_times))] == t

--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -1,8 +1,22 @@
 """
+    track_callbacks(cb, t, u, p, sensealg)
+
 Appends a tracking process to determine the time of the callback to be used in
 the reverse pass. The rationale is explain in:
 
 https://github.com/SciML/SciMLSensitivity.jl/issues/4
+
+Differentiating through `solve` does this automatically. Call it directly to run
+a forward solve whose events a later [`adjoint_sensitivities`](@ref) can account
+for:
+
+```julia
+cb = SciMLSensitivity.track_callbacks(
+    prob.kwargs[:callback], prob.tspan[1], prob.u0, prob.p, sensealg)
+sol = solve(remake(prob; kwargs = merge(values(prob.kwargs), (; callback = cb))), alg;
+    save_everystep = true)
+du0, dp = adjoint_sensitivities(sol, alg; t = ts, sensealg, dgdu_discrete)
+```
 """
 track_callbacks(cb, t, u, p, sensealg) = track_callbacks(CallbackSet(cb), t, u, p, sensealg)
 function track_callbacks(cb::CallbackSet, t, u, p, sensealg)
@@ -141,6 +155,92 @@ function (f::TrackedAffect)(integrator, event_idx = nothing)
     end
 end
 
+# A `ContinuousCallback` may be built with `affect_neg! = nothing`, in which case
+# tracking leaves the negative-crossing affect `nothing` and no event is ever
+# recorded for it.
+const NO_EVENT_TIMES = Float64[]
+tracked_event_times(affect) = affect.event_times
+tracked_event_times(::Nothing) = NO_EVENT_TIMES
+
+is_tracked_affect(::TrackedAffect) = true
+is_tracked_affect(::Nothing) = true
+is_tracked_affect(affect) = false
+
+function is_tracked_callback(cb::ContinuousCallback)
+    return is_tracked_affect(cb.affect!) && is_tracked_affect(cb.affect_neg!)
+end
+is_tracked_callback(cb::Union{DiscreteCallback, VectorContinuousCallback}) = is_tracked_affect(cb.affect!)
+
+"""
+    all_callbacks_tracked(cb)
+
+Whether every affect in `cb` is a [`TrackedAffect`](@ref) (or `nothing`), i.e. the
+callbacks were run through [`track_callbacks`](@ref) on the forward pass and hence
+carry the event times, left limits and event-time correction the adjoint needs.
+"""
+function all_callbacks_tracked(cb)
+    cbs = CallbackSet(cb)
+    return all(is_tracked_callback, cbs.continuous_callbacks) &&
+        all(is_tracked_callback, cbs.discrete_callbacks)
+end
+
+"""
+    problem_callback(prob)
+
+The callback attached to the problem itself (`prob.kwargs[:callback]`), or
+`nothing` when there is none.
+"""
+function problem_callback(prob)
+    hasproperty(prob, :kwargs) || return nothing
+    return get(prob.kwargs, :callback, nothing)
+end
+
+function is_empty_callback(cb)
+    cb === nothing && return true
+    cb isa CallbackSet || return false
+    return isempty(cb.continuous_callbacks) && isempty(cb.discrete_callbacks)
+end
+
+const UNTRACKED_CALLBACK_MESSAGE = """
+The forward solution was computed with callbacks that were not tracked, so the adjoint cannot account for the events: the event times and the state and parameter values just before each event are not recorded anywhere in the solution, and ignoring them would silently give a wrong gradient.
+
+Two routes are supported:
+
+  1. Differentiate through `solve` with Zygote (or any other ChainRules-based AD), which tracks the callbacks automatically:
+
+         Zygote.gradient(u0 -> loss(solve(remake(prob; u0), alg; sensealg)), u0)
+
+  2. Run the forward solve with tracked callbacks, and hand the resulting solution to `adjoint_sensitivities`:
+
+         cb = SciMLSensitivity.track_callbacks(
+             prob.kwargs[:callback], prob.tspan[1], prob.u0, prob.p, sensealg)
+         _prob = remake(prob; kwargs = merge(values(prob.kwargs), (; callback = cb)))
+         sol = solve(_prob, alg; save_everystep = true)
+         du0, dp = adjoint_sensitivities(sol, alg; t = ts, sensealg, dgdu_discrete)
+
+     Equivalently, keep the problem as it is and pass the tracked set to both calls:
+     `solve(prob, alg; callback = cb, merge_callbacks = false)` and
+     `adjoint_sensitivities(sol, alg; callback = cb, ...)`.
+
+To run the adjoint without any event correction anyway, pass `callback` explicitly.
+"""
+
+"""
+    adjoint_callbacks(sol, callback)
+
+The callbacks the adjoint pass should use. When the caller did not pass any, the
+callbacks attached to the forward problem are used, provided they were tracked;
+untracked ones throw, because the reverse pass would otherwise drop the event
+correction silently.
+"""
+function adjoint_callbacks(sol, callback)
+    is_empty_callback(callback) || return callback
+    cb = problem_callback(sol.prob)
+    is_empty_callback(cb) && return callback
+    all_callbacks_tracked(cb) || throw(ArgumentError(UNTRACKED_CALLBACK_MESSAGE))
+    return CallbackSet(cb)
+end
+
 function _track_callback(cb::DiscreteCallback, t, u, p, sensealg)
     correction = ImplicitCorrection(cb, t, u, p, sensealg)
     return DiscreteCallback(
@@ -148,7 +248,9 @@ function _track_callback(cb::DiscreteCallback, t, u, p, sensealg)
         TrackedAffect(t, u, p, cb.affect!, correction),
         cb.initialize,
         cb.finalize,
-        cb.save_positions
+        cb.save_positions,
+        cb.initializealg, cb.saved_clock_partitions,
+        cb.initialize_save_discretes
     )
 end
 
@@ -163,7 +265,9 @@ function _track_callback(cb::ContinuousCallback, t, u, p, sensealg)
         cb.idxs,
         cb.rootfind, cb.interp_points,
         cb.save_positions,
-        cb.dtrelax, cb.abstol, cb.reltol, cb.repeat_nudge
+        cb.dtrelax, cb.abstol, cb.reltol, cb.repeat_nudge,
+        cb.initializealg, cb.saved_clock_partitions,
+        cb.maybe_discontinuity, cb.initialize_save_discretes
     )
 end
 
@@ -194,6 +298,113 @@ end
 function Base.getproperty(fi::FakeIntegrator, s::Symbol)
     s === :tdir && return sign(fi.t - fi.tprev)
     return getfield(fi, s)
+end
+
+# SymbolicIndexingInterface surface. Affects that are compiled from a symbolic
+# description (e.g. ModelingToolkit's imperative and functional affects, and the
+# `setu`/`setp` setters they build) reach the integrator through this interface
+# rather than through the `.u`/`.p` fields, so the fake integrator has to answer
+# it too. `getfield` is used throughout because `getproperty` is overloaded above.
+# The `set_state!`/`set_parameter!` defaults would already do the right thing;
+# they are spelled out because they are the mutating half of the contract.
+SymbolicIndexingInterface.state_values(fi::FakeIntegrator) = getfield(fi, :u)
+SymbolicIndexingInterface.parameter_values(fi::FakeIntegrator) = getfield(fi, :p)
+SymbolicIndexingInterface.current_time(fi::FakeIntegrator) = getfield(fi, :t)
+function SymbolicIndexingInterface.set_state!(fi::FakeIntegrator, val, idx)
+    return getfield(fi, :u)[idx] = val
+end
+function SymbolicIndexingInterface.set_parameter!(fi::FakeIntegrator, val, idx)
+    return SymbolicIndexingInterface.set_parameter!(getfield(fi, :p), val, idx)
+end
+
+"""
+    is_structured_p(p)
+
+Whether `p` is a SciMLStructure that is not itself an `AbstractArray`, i.e. a
+parameter object whose tunable values have to be reached through
+`SciMLStructures.canonicalize`. Plain arrays are already canonical and must not be
+canonicalized a second time (see SciMLSensitivity#1605), and `nothing` /
+`NullParameters` are not SciMLStructures at all.
+"""
+is_structured_p(p) = isscimlstructure(p) && !(p isa AbstractArray)
+
+"""
+    canonical_tunables(p)
+
+The flat tunable portion of `p`, or `p` unchanged when it is already flat.
+"""
+function canonical_tunables(p)
+    is_structured_p(p) || return p
+    return canonicalize(Tunable(), p)[1]
+end
+
+# Portions of a SciMLStructure a callback affect may legitimately write to.
+# `Caches` is deliberately absent: it is scratch space, not parameter state.
+const CALLBACK_P_PORTIONS = (
+    SciMLStructures.Tunable(), SciMLStructures.Initials(),
+    SciMLStructures.Discrete(), SciMLStructures.Constants(),
+)
+
+"""
+    portion_values(portion, p)
+
+The canonicalized values of `portion` in `p`, or `nothing` when `p` has no such
+portion. A structure signals an absent portion either by not defining
+`canonicalize` for it or by returning `nothing` from it.
+"""
+function portion_values(portion, p)
+    applicable(SciMLStructures.canonicalize, portion, p) || return nothing
+    return first(SciMLStructures.canonicalize(portion, p))
+end
+
+"""
+    p_isequal(p, pleft)
+
+Whether two parameter objects hold the same values. `==` covers plain arrays as
+well as parameter structures that define it (such as ModelingToolkit's).
+"""
+p_isequal(p, pleft) = p == pleft
+
+"""
+    copy_p!(p, pleft)
+
+Copy the parameter values of `pleft` into `p` in place. Plain arrays are copied
+with `copyto!`. A mutable SciMLStructure is copied portion by portion, because an
+affect may change discrete or otherwise non-tunable parameters as well as tunable
+ones.
+"""
+function copy_p!(p, pleft)
+    is_structured_p(p) || return copyto!(p, pleft)
+    SciMLStructures.ismutablescimlstructure(p) ||
+        error("The callback changes the parameters, but $(typeof(p)) is not a mutable SciMLStructure so the adjoint pass cannot restore them. Implement `SciMLStructures.replace!` for it.")
+    for portion in CALLBACK_P_PORTIONS
+        vals = portion_values(portion, pleft)
+        (vals === nothing || isempty(vals)) && continue
+        SciMLStructures.replace!(portion, p, vals)
+    end
+    return p
+end
+
+"""
+    detached_p(p, tunables)
+
+The structured parameter object `p` with `tunables` as its tunable portion and
+every other numeric portion detached from `p`'s storage. The callback affect
+wrappers hand this to the affect, which is free to mutate it; without the detach
+an affect that writes a non-tunable parameter would corrupt the recorded left
+limit it was built from, and that recording is replayed on every tape evaluation.
+"""
+function detached_p(p, tunables)
+    q = SciMLStructures.replace(Tunable(), p, tunables)
+    for portion in (
+            SciMLStructures.Initials(), SciMLStructures.Discrete(),
+            SciMLStructures.Constants(),
+        )
+        vals = portion_values(portion, q)
+        (vals === nothing || isempty(vals)) && continue
+        q = SciMLStructures.replace(portion, q, copy(vals))
+    end
+    return q
 end
 
 struct CallbackSensitivityFunction{
@@ -514,7 +725,9 @@ function (ff::CallbackAffectPWrapper)(dp, u, p, t)
     else
         _affect!(fakeinteg)
     end
-    dp .= fakeinteg.p
+    # `dp` is tunables-sized (see `_get_wp_paramjac_config`), so a structured `p`
+    # has to be canonicalized before it can be written back.
+    dp .= canonical_tunables(fakeinteg.p)
     return nothing
 end
 
@@ -530,14 +743,27 @@ function setup_w_wp(
 end
 
 function get_FakeIntegrator(autojacvec::ReverseDiffVJP, u, p, t, tprev)
-    return FakeIntegrator([x for x in u], [x for x in p], t, tprev)
+    return FakeIntegrator([x for x in u], fake_integrator_p(p), t, tprev)
+end
+
+# The comprehension turns a ReverseDiff `TrackedArray` into a `Vector{TrackedReal}`,
+# which is what makes the affect's `setindex!` of a tracked scalar work. For a
+# structured `p` the tunables get the same treatment and are repacked, so the
+# affect still sees the parameter object it expects.
+fake_integrator_p(p) = is_structured_p(p) ? fake_integrator_structured_p(p) : [x for x in p]
+function fake_integrator_structured_p(p)
+    tunables = canonicalize(Tunable(), p)[1]
+    return detached_p(p, [x for x in tunables])
 end
 get_FakeIntegrator(autojacvec::EnzymeVJP, u, p, t, tprev) = FakeIntegrator(u, p, t, tprev)
 get_FakeIntegrator(autojacvec::ReactantVJP, u, p, t, tprev) = FakeIntegrator(u, p, t, tprev)
 get_FakeIntegrator(autojacvec::MooncakeVJP, u, p, t, tprev) = FakeIntegrator(u, p, t, tprev)
 
 function _get_wp_paramjac_config(autojacvec::EnzymeVJP, _p, wp, y, __p, _t)
-    return (zero(y), zero(_p), zero(_p), zero(_p), zero(y))
+    # The shadow, the `wp` output and the seed are all tunables-sized; the
+    # structured object itself is rebuilt by `repack` in `_vecjacobian!`.
+    _pt = canonical_tunables(_p)
+    return (zero(y), zero(_pt), zero(_pt), zero(_pt), zero(y))
 end
 
 function _get_wp_paramjac_config(autojacvec::ReverseDiffVJP, _p, wp, y, __p, _t)
@@ -571,7 +797,7 @@ function get_cb_diffcaches(
     vcc = cb isa VectorContinuousCallback
     cc = cb isa ContinuousCallback
     has_affect = !isempty(cb.affect!.event_times)
-    has_affect_neg = cc && !isempty(cb.affect_neg!.event_times)
+    has_affect_neg = cc && !isempty(tracked_event_times(cb.affect_neg!))
     pos_negs = cc ? (true, false) : (true,)
     event_idxs = vcc ? eachindex(cb.affect!.event_times) : (nothing,)
     for event_idx in event_idxs
@@ -660,8 +886,13 @@ function get_cb_diffcaches(
                 else
                     w, wp = setup_w_wp(cb, autojacvec, pos_neg, cache_event_idx, _t)
 
+                    # The tape (or Enzyme shadow) is built over the *tunables*,
+                    # while `_p` stays the full parameter object so that the
+                    # config derives the matching `repack` from it.
+                    _pt = canonical_tunables(_p)
+
                     paramjac_config = get_paramjac_config(
-                        autojacvec, _p, w, y, _p, _t;
+                        autojacvec, _p, w, y, _pt, _t;
                         numindvar = length(y), alg = nothing,
                         isinplace = true, isRODE = false,
                         _W = nothing
@@ -681,7 +912,7 @@ function get_cb_diffcaches(
                     )
 
                     paramjac_config = _get_wp_paramjac_config(
-                        autojacvec, _p, wp, y, _p, _t
+                        autojacvec, _p, wp, y, _pt, _t
                     )
                     pf = get_pf(autojacvec; _f = wp, isinplace = true, isRODE = false)
                     if autojacvec isa EnzymeVJP
@@ -712,20 +943,15 @@ function get_indx(cb::VectorContinuousCallback, t)
     return (searchsortedfirst(cb.affect!.event_times, t), true)
 end
 function get_indx(cb::ContinuousCallback, t)
-    return if !isempty(cb.affect!.event_times) || !isempty(cb.affect_neg!.event_times)
+    neg_event_times = tracked_event_times(cb.affect_neg!)
+    return if !isempty(cb.affect!.event_times) || !isempty(neg_event_times)
         indx = searchsortedfirst(cb.affect!.event_times, t)
-        indx_neg = searchsortedfirst(cb.affect_neg!.event_times, t)
+        indx_neg = searchsortedfirst(neg_event_times, t)
         if !isempty(cb.affect!.event_times) &&
                 cb.affect!.event_times[min(indx, length(cb.affect!.event_times))] == t
             return indx, true
-        elseif !isempty(cb.affect_neg!.event_times) &&
-                cb.affect_neg!.event_times[
-                min(
-                    indx_neg,
-                    length(cb.affect_neg!.event_times)
-                ),
-            ] ==
-                t
+        elseif !isempty(neg_event_times) &&
+                neg_event_times[min(indx_neg, length(neg_event_times))] == t
             return indx_neg, false
         else
             error("Event was triggered but no corresponding event in ContinuousCallback was found. Please report this error.")
@@ -751,27 +977,27 @@ function copy_to_integrator!(cb::DiscreteCallback, y, p, indx, bool)
     # For BacksolveAdjoint, y is a view to the integrator state;
     # for the other methods, it's the S.y cache
     copyto!(y, cb.affect!.uleft[indx])
-    update_p = (p != cb.affect!.pleft[indx])
-    update_p && copyto!(p, cb.affect!.pleft[indx])
+    update_p = !p_isequal(p, cb.affect!.pleft[indx])
+    update_p && copy_p!(p, cb.affect!.pleft[indx])
     return update_p
 end
 
 function copy_to_integrator!(cb::VectorContinuousCallback, y, p, indx, bool)
     copyto!(y, cb.affect!.uleft[indx])
-    update_p = (p != cb.affect!.pleft[indx])
-    update_p && copyto!(p, cb.affect!.pleft[indx])
+    update_p = !p_isequal(p, cb.affect!.pleft[indx])
+    update_p && copy_p!(p, cb.affect!.pleft[indx])
     return update_p
 end
 
 function copy_to_integrator!(cb::ContinuousCallback, y, p, indx, bool)
     if bool
         copyto!(y, cb.affect!.uleft[indx])
-        update_p = (p != cb.affect!.pleft[indx])
-        update_p && copyto!(p, cb.affect!.pleft[indx])
+        update_p = !p_isequal(p, cb.affect!.pleft[indx])
+        update_p && copy_p!(p, cb.affect!.pleft[indx])
     else
         copyto!(y, cb.affect_neg!.uleft[indx])
-        update_p = (p != cb.affect_neg!.pleft[indx])
-        update_p && copyto!(p, cb.affect_neg!.pleft[indx])
+        update_p = !p_isequal(p, cb.affect_neg!.pleft[indx])
+        update_p && copy_p!(p, cb.affect_neg!.pleft[indx])
     end
     return update_p
 end

--- a/src/gauss_adjoint.jl
+++ b/src/gauss_adjoint.jl
@@ -76,7 +76,10 @@ function ODEGaussAdjointSensitivityFunction(
         else
             if maximum(interval[1] .< tstops .< interval[2])
                 # callback might have changed p
-                _p = Gaussreset_p(sol.prob.kwargs[:callback], interval)
+                _p = Gaussreset_p(
+                    get(sol.prob.kwargs, :callback, nothing), interval,
+                    parameter_values(sol.prob)
+                )
                 #cpsol = solve(remake(sol.prob; tspan = interval, u0 = sol(interval[1])),
                 #    tstops, p = _p, sol.alg; tols...)
 
@@ -193,7 +196,10 @@ function split_states(du, u, t, S::ODEGaussAdjointSensitivityFunction; update = 
                 else
                     if maximum(interval[1] .< checkpoint_sol.tstops .< interval[2])
                         # callback might have changed p
-                        _p = reset_p(prob.kwargs[:callback], interval)
+                        _p = reset_p(
+                            get(prob.kwargs, :callback, nothing), interval,
+                            parameter_values(prob)
+                        )
                         prob′ = remake(prob, tspan = intervals[cursor′], u0 = y, p = _p)
                         cpsol′ = solve(
                             prob′, sol.alg;
@@ -241,7 +247,10 @@ function Gaussupdate_checkpoint_sol!(S::ODEGaussAdjointSensitivityFunction, t)
         else
             if maximum(interval[1] .< checkpoint_sol.tstops .< interval[2])
                 # callback might have changed p
-                _p = reset_p(prob.kwargs[:callback], interval)
+                _p = reset_p(
+                    get(prob.kwargs, :callback, nothing), interval,
+                    parameter_values(prob)
+                )
                 prob′ = remake(prob, tspan = intervals[cursor′], u0 = y₀, p = _p)
                 cpsol′ = solve(
                     prob′, sol.alg; dt,
@@ -411,82 +420,8 @@ end
     end
 end
 
-function Gaussreset_p(CBS, interval)
-    # check which events are close to tspan[1]
-    if !isempty(CBS.discrete_callbacks)
-        ts = map(CBS.discrete_callbacks) do cb
-            indx = searchsortedfirst(cb.affect!.event_times, interval[1])
-            (indx, cb.affect!.event_times[indx])
-        end
-        perm = minimum(sortperm([t for t in getindex.(ts, 2)]))
-    end
-
-    if !isempty(CBS.continuous_callbacks)
-        ts2 = map(CBS.continuous_callbacks) do cb
-            if !isempty(cb.affect!.event_times) && isempty(cb.affect_neg!.event_times)
-                indx = searchsortedfirst(cb.affect!.event_times, interval[1])
-                return (indx, cb.affect!.event_times[indx], 0) # zero for affect!
-            elseif isempty(cb.affect!.event_times) && !isempty(cb.affect_neg!.event_times)
-                indx = searchsortedfirst(cb.affect_neg!.event_times, interval[1])
-                return (indx, cb.affect_neg!.event_times[indx], 1) # one for affect_neg!
-            elseif !isempty(cb.affect!.event_times) && !isempty(cb.affect_neg!.event_times)
-                indx1 = searchsortedfirst(cb.affect!.event_times, interval[1])
-                indx2 = searchsortedfirst(cb.affect_neg!.event_times, interval[1])
-                if cb.affect!.event_times[indx1] < cb.affect_neg!.event_times[indx2]
-                    return (indx1, cb.affect!.event_times[indx1], 0)
-                else
-                    return (indx2, cb.affect_neg!.event_times[indx2], 1)
-                end
-            else
-                error("Expected event but reset_p couldn't find event time. Please report this error.")
-            end
-        end
-        perm2 = minimum(sortperm([t for t in getindex.(ts2, 2)]))
-        # check if continuous or discrete callback was applied first if both occur in interval
-        if isempty(CBS.discrete_callbacks)
-            if ts2[perm2][3] == 0
-                p = deepcopy(CBS.continuous_callbacks[perm2].affect!.pleft[getindex.(ts2, 1)[perm2]])
-            else
-                p = deepcopy(
-                    CBS.continuous_callbacks[perm2].affect_neg!.pleft[
-                        getindex.(
-                            ts2,
-                            1
-                        )[perm2],
-                    ]
-                )
-            end
-        else
-            if ts[perm][2] < ts2[perm2][2]
-                p = deepcopy(CBS.discrete_callbacks[perm].affect!.pleft[getindex.(ts, 1)[perm]])
-            else
-                if ts2[perm2][3] == 0
-                    p = deepcopy(
-                        CBS.continuous_callbacks[perm2].affect!.pleft[
-                            getindex.(
-                                ts2,
-                                1
-                            )[perm2],
-                        ]
-                    )
-                else
-                    p = deepcopy(
-                        CBS.continuous_callbacks[perm2].affect_neg!.pleft[
-                            getindex.(
-                                ts2,
-                                1
-                            )[perm2],
-                        ]
-                    )
-                end
-            end
-        end
-    else
-        p = deepcopy(CBS.discrete_callbacks[perm].affect!.pleft[getindex.(ts, 1)[perm]])
-    end
-
-    return p
-end
+# `Gaussreset_p` was a verbatim copy of `reset_p`; keep the name for callers.
+const Gaussreset_p = reset_p
 
 function GaussIntegrand(sol, sensealg, checkpoints, dgdp = nothing)
     prob = sol.prob
@@ -789,6 +724,7 @@ function _adjoint_sensitivities(
         callback = CallbackSet(), no_start = false,
         kwargs...
     )
+    callback = adjoint_callbacks(sol, callback)
     p = SymbolicIndexingInterface.parameter_values(sol)
     if !isscimlstructure(p) && !isfunctor(p) &&
             !(p isa Union{Nothing, SciMLBase.NullParameters, AbstractArray})

--- a/src/gauss_adjoint.jl
+++ b/src/gauss_adjoint.jl
@@ -76,7 +76,7 @@ function ODEGaussAdjointSensitivityFunction(
         else
             if maximum(interval[1] .< tstops .< interval[2])
                 # callback might have changed p
-                _p = Gaussreset_p(
+                _p = reset_p(
                     get(sol.prob.kwargs, :callback, nothing), interval,
                     parameter_values(sol.prob)
                 )
@@ -419,9 +419,6 @@ end
         return ODEProblem(odefun, z0, tspan, p, callback = cb), cb, rcb
     end
 end
-
-# `Gaussreset_p` was a verbatim copy of `reset_p`; keep the name for callers.
-const Gaussreset_p = reset_p
 
 function GaussIntegrand(sol, sensealg, checkpoints, dgdp = nothing)
     prob = sol.prob

--- a/src/interpolating_adjoint.jl
+++ b/src/interpolating_adjoint.jl
@@ -776,18 +776,19 @@ function reset_p(CBS, interval, default_p)
 
     if !isempty(CBS.continuous_callbacks)
         ts2 = map(CBS.continuous_callbacks) do cb
+            pos_event_times = tracked_event_times(cb.affect!)
             neg_event_times = tracked_event_times(cb.affect_neg!)
-            if !isempty(cb.affect!.event_times) && isempty(neg_event_times)
-                indx = searchsortedfirst(cb.affect!.event_times, interval[1])
-                return (indx, cb.affect!.event_times[indx], 0) # zero for affect!
-            elseif isempty(cb.affect!.event_times) && !isempty(neg_event_times)
+            if !isempty(pos_event_times) && isempty(neg_event_times)
+                indx = searchsortedfirst(pos_event_times, interval[1])
+                return (indx, pos_event_times[indx], 0) # zero for affect!
+            elseif isempty(pos_event_times) && !isempty(neg_event_times)
                 indx = searchsortedfirst(neg_event_times, interval[1])
                 return (indx, neg_event_times[indx], 1) # one for affect_neg!
-            elseif !isempty(cb.affect!.event_times) && !isempty(neg_event_times)
-                indx1 = searchsortedfirst(cb.affect!.event_times, interval[1])
+            elseif !isempty(pos_event_times) && !isempty(neg_event_times)
+                indx1 = searchsortedfirst(pos_event_times, interval[1])
                 indx2 = searchsortedfirst(neg_event_times, interval[1])
-                if cb.affect!.event_times[indx1] < neg_event_times[indx2]
-                    return (indx1, cb.affect!.event_times[indx1], 0)
+                if pos_event_times[indx1] < neg_event_times[indx2]
+                    return (indx1, pos_event_times[indx1], 0)
                 else
                     return (indx2, neg_event_times[indx2], 1)
                 end

--- a/src/interpolating_adjoint.jl
+++ b/src/interpolating_adjoint.jl
@@ -93,7 +93,10 @@ function ODEInterpolatingAdjointSensitivityFunction(
             else
                 if maximum(interval[1] .< tstops .< interval[2])
                     # callback might have changed p
-                    _p = reset_p(sol.prob.kwargs[:callback], interval)
+                    _p = reset_p(
+                        get(sol.prob.kwargs, :callback, nothing), interval,
+                        parameter_values(sol.prob)
+                    )
                     cpsol = solve(
                         remake(sol.prob, tspan = interval, u0 = sol(interval[1]));
                         tstops, p = _p, sol.alg, tols...
@@ -252,7 +255,10 @@ function split_states(
                     else
                         if maximum(interval[1] .< checkpoint_sol.tstops .< interval[2])
                             # callback might have changed p
-                            _p = reset_p(prob.kwargs[:callback], interval)
+                            _p = reset_p(
+                                get(prob.kwargs, :callback, nothing), interval,
+                                parameter_values(prob)
+                            )
                             prob′ = remake(prob, tspan = intervals[cursor′], u0 = y, p = _p)
                             cpsol′ = solve(
                                 prob′, sol.alg;
@@ -745,7 +751,20 @@ end
     )
 end
 
-function reset_p(CBS, interval)
+"""
+    reset_p(CBS, interval, default_p)
+
+The parameter values in force at the start of `interval`, read back from the left
+limits recorded by the tracked callbacks in `CBS` (a callback may have changed the
+parameters inside the checkpointing interval). Falls back to `default_p` when the
+forward callbacks were not tracked, in which case no such record exists.
+"""
+function reset_p(CBS, interval, default_p)
+    CBS = CallbackSet(CBS)
+    isempty(CBS.discrete_callbacks) && isempty(CBS.continuous_callbacks) &&
+        return default_p
+    all_callbacks_tracked(CBS) || return default_p
+
     # check which events are close to tspan[1]
     if !isempty(CBS.discrete_callbacks)
         ts = map(CBS.discrete_callbacks) do cb
@@ -757,19 +776,20 @@ function reset_p(CBS, interval)
 
     if !isempty(CBS.continuous_callbacks)
         ts2 = map(CBS.continuous_callbacks) do cb
-            if !isempty(cb.affect!.event_times) && isempty(cb.affect_neg!.event_times)
+            neg_event_times = tracked_event_times(cb.affect_neg!)
+            if !isempty(cb.affect!.event_times) && isempty(neg_event_times)
                 indx = searchsortedfirst(cb.affect!.event_times, interval[1])
                 return (indx, cb.affect!.event_times[indx], 0) # zero for affect!
-            elseif isempty(cb.affect!.event_times) && !isempty(cb.affect_neg!.event_times)
-                indx = searchsortedfirst(cb.affect_neg!.event_times, interval[1])
-                return (indx, cb.affect_neg!.event_times[indx], 1) # one for affect_neg!
-            elseif !isempty(cb.affect!.event_times) && !isempty(cb.affect_neg!.event_times)
+            elseif isempty(cb.affect!.event_times) && !isempty(neg_event_times)
+                indx = searchsortedfirst(neg_event_times, interval[1])
+                return (indx, neg_event_times[indx], 1) # one for affect_neg!
+            elseif !isempty(cb.affect!.event_times) && !isempty(neg_event_times)
                 indx1 = searchsortedfirst(cb.affect!.event_times, interval[1])
-                indx2 = searchsortedfirst(cb.affect_neg!.event_times, interval[1])
-                if cb.affect!.event_times[indx1] < cb.affect_neg!.event_times[indx2]
+                indx2 = searchsortedfirst(neg_event_times, interval[1])
+                if cb.affect!.event_times[indx1] < neg_event_times[indx2]
                     return (indx1, cb.affect!.event_times[indx1], 0)
                 else
-                    return (indx2, cb.affect_neg!.event_times[indx2], 1)
+                    return (indx2, neg_event_times[indx2], 1)
                 end
             else
                 error("Expected event but reset_p couldn't find event time. Please report this error.")

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -546,6 +546,7 @@ function _adjoint_sensitivities(
         callback = CallbackSet(),
         kwargs...
     )
+    callback = adjoint_callbacks(sol, callback)
     adj_prob,
         rcb = if sol.prob isa SciMLBase.AbstractDAEProblem
         DAEAdjointProblem(
@@ -701,7 +702,9 @@ function update_integrand_and_dgrad(
         adj_prob, sol, dgdu_discrete, dgdp_discrete, dλ, dgrad,
         ti, cur_time
     )
+    callbacks = CallbackSet(callbacks)
     for cb in callbacks.discrete_callbacks
+        is_tracked_callback(cb) || continue
         if ti ∈ cb.affect!.event_times
             integrand = _update_integrand_and_dgrad(
                 res, sensealg, cb,
@@ -713,8 +716,9 @@ function update_integrand_and_dgrad(
         end
     end
     for cb in callbacks.continuous_callbacks
+        is_tracked_callback(cb) || continue
         if ti ∈ cb.affect!.event_times ||
-                ti ∈ cb.affect_neg!.event_times
+                ti ∈ tracked_event_times(cb.affect_neg!)
             integrand = _update_integrand_and_dgrad(
                 res, sensealg, cb,
                 integrand, adj_prob, sol,
@@ -741,11 +745,13 @@ function _update_integrand_and_dgrad(
 
     wp = CallbackAffectPWrapper(cb, cb_autojacvec, pos_neg, nothing, tprev)
 
-    _p = similar(integrand.p, size(integrand.p))
-    _p .= false
-    wp(_p, integrand.y, integrand.p, t)
+    # `wp` writes the tunable portion of the post-event parameters; the integrand
+    # is rebuilt from the full parameter object, so repack before comparing.
+    _pt = similar(integrand.tunables, size(integrand.tunables))
+    _pt .= false
+    wp(_pt, integrand.y, integrand.p, t)
 
-    if _p != integrand.p
+    if _pt != integrand.tunables
         paramjac_config = _get_wp_paramjac_config(
             cb_autojacvec, integrand.p, wp, integrand.y, integrand.p, t
         )
@@ -769,7 +775,7 @@ function _update_integrand_and_dgrad(
             nothing, integrand.y, res, integrand.p, t, fakeSp;
             dgrad = res, dy = nothing
         )
-        integrand = update_p_integrand(integrand, _p)
+        integrand = update_p_integrand(integrand, integrand.repack(_pt))
     end
 
     w = CallbackAffectWrapper(cb, cb_autojacvec, pos_neg, nothing, tprev)

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -717,7 +717,7 @@ function update_integrand_and_dgrad(
     end
     for cb in callbacks.continuous_callbacks
         is_tracked_callback(cb) || continue
-        if ti ∈ cb.affect!.event_times ||
+        if ti ∈ tracked_event_times(cb.affect!) ||
                 ti ∈ tracked_event_times(cb.affect_neg!)
             integrand = _update_integrand_and_dgrad(
                 res, sensealg, cb,

--- a/src/sensitivity_interface.jl
+++ b/src/sensitivity_interface.jl
@@ -403,11 +403,10 @@ function adjoint_sensitivities(
     end
 
     if hasfield(typeof(sensealg), :autojacvec) && sensealg.autojacvec === nothing
-        if haskey(kwargs, :callback)
-            has_cb = kwargs[:callback] !== nothing
-        else
-            has_cb = false
-        end
+        # A callback attached to the problem itself counts too: `_adjoint_sensitivities`
+        # picks it up when the caller passes none.
+        has_cb = !is_empty_callback(get(kwargs, :callback, nothing)) ||
+            !is_empty_callback(problem_callback(prob))
 
         _sensealg = if isinplace(sol.prob)
             setvjp(
@@ -470,6 +469,7 @@ function _adjoint_sensitivities(
         callback = nothing,
         kwargs...
     )
+    callback = adjoint_callbacks(sol, callback)
     mtkp = SymbolicIndexingInterface.parameter_values(sol)
     if !(mtkp isa Union{Nothing, SciMLBase.NullParameters, AbstractArray}) &&
             !isscimlstructure(mtkp) ||

--- a/src/sensitivity_interface.jl
+++ b/src/sensitivity_interface.jl
@@ -406,7 +406,7 @@ function adjoint_sensitivities(
         # A callback attached to the problem itself counts too: `_adjoint_sensitivities`
         # picks it up when the caller passes none.
         has_cb = !is_empty_callback(get(kwargs, :callback, nothing)) ||
-            !is_empty_callback(problem_callback(prob))
+            !is_empty_callback(get(prob.kwargs, :callback, nothing))
 
         _sensealg = if isinplace(sol.prob)
             setvjp(

--- a/test/Core8/mtk_events.jl
+++ b/test/Core8/mtk_events.jl
@@ -361,4 +361,41 @@ const CONTINUOUS_SENSEALGS = [
             @test gFD ≈ Zygote.gradient(p -> loss(p, sensealg), p)[1] rtol = 1.0e-10
         end
     end
+
+    @testset "affect_neg!-only ContinuousCallback" begin
+        # A `ContinuousCallback` may be built with `affect! = nothing`, so that only
+        # the negative crossing fires and only it records events.
+        u0 = [1.0, 0.0]
+        p = [9.81, 0.7]
+        tspan = (0.0, 0.8)
+
+        function ball!(du, u, p, t)
+            du[1] = u[2]
+            du[2] = -p[1]
+            return nothing
+        end
+        condition(u, t, integrator) = u[1]
+        bounce!(integrator) = (integrator.u[2] = -integrator.p[2] * integrator.u[2])
+        cb = ContinuousCallback(
+            condition, nothing, bounce!, save_positions = (false, false)
+        )
+        prob = ODEProblem(ball!, u0, tspan, p)
+
+        function loss(u0, p, sensealg)
+            _sol = solve(
+                remake(prob; u0, p), Tsit5(); callback = cb,
+                abstol = 1.0e-12, reltol = 1.0e-12, sensealg
+            )
+            return sum(abs2, _sol.u[end])
+        end
+
+        # The reverse pass now runs the tracked negative-crossing affect (before,
+        # a callback without `affect!` was silently dropped from the reverse
+        # pass), but the event-time correction for this case is still wrong.
+        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP())
+        @test_broken ForwardDiff.gradient(x -> loss(x, p, nothing), u0) ≈
+            Zygote.gradient(x -> loss(x, p, sensealg), u0)[1] rtol = 1.0e-6
+        @test_broken ForwardDiff.gradient(x -> loss(u0, x, nothing), p) ≈
+            Zygote.gradient(x -> loss(u0, x, sensealg), p)[1] rtol = 1.0e-6
+    end
 end

--- a/test/Core8/mtk_events.jl
+++ b/test/Core8/mtk_events.jl
@@ -1,0 +1,364 @@
+using ModelingToolkit, OrdinaryDiffEq, SciMLSensitivity
+using ModelingToolkit: t_nounits as t, D_nounits as D
+using Zygote, ForwardDiff, FiniteDiff
+using SciMLBase
+import SciMLStructures as SS
+using SymbolicIndexingInterface
+using Test
+
+# Reverse-mode adjoints for ModelingToolkit systems with events. The parameter
+# object of such a system is a SciMLStructure rather than a plain vector, which
+# the callback VJP path has to canonicalize. See SciML/ModelingToolkit.jl#5018.
+
+# Bouncing ball in the shape of the Reference-FMU model: h(0) = 1, v(0) = 0,
+# g = 9.81, restitution e = 0.7.
+const H0 = 1.0
+const V0 = 0.0
+const G0 = 9.81
+const E0 = 0.7
+
+const ABSTOL = 1.0e-10
+const RELTOL = 1.0e-10
+const SAVEAT = 0.0:0.25:2.0
+
+"""
+Gradients of `sum(abs2, u[idx](t))` over `SAVEAT` with respect to `u0` and to the
+tunable parameters, computed with each of `sensealgs` and compared against finite
+differences.
+"""
+function test_event_gradients(prob, idx; sensealgs, rtol = 1.0e-4, name = "")
+    tunables, repack, _ = SS.canonicalize(SS.Tunable(), prob.p)
+    tunables = collect(tunables)
+
+    lossu0(u0, sensealg) = sum(
+        abs2,
+        Array(
+            solve(
+                remake(prob; u0), Tsit5();
+                saveat = SAVEAT, abstol = ABSTOL, reltol = RELTOL, sensealg
+            )
+        )[idx, :]
+    )
+    lossp(x, sensealg) = sum(
+        abs2,
+        Array(
+            solve(
+                prob, Tsit5(); p = repack(x),
+                saveat = SAVEAT, abstol = ABSTOL, reltol = RELTOL, sensealg
+            )
+        )[idx, :]
+    )
+
+    fd_u0 = FiniteDiff.finite_difference_gradient(u0 -> lossu0(u0, nothing), prob.u0)
+    fd_p = FiniteDiff.finite_difference_gradient(x -> lossp(x, nothing), tunables)
+
+    for (sensename, sensealg) in sensealgs
+        @testset "$name $sensename" begin
+            du0 = Zygote.gradient(u0 -> lossu0(u0, sensealg), prob.u0)[1]
+            @test du0 ≈ fd_u0 rtol = rtol
+            if !isempty(tunables)
+                dp = Zygote.gradient(x -> lossp(x, sensealg), tunables)[1]
+                @test dp ≈ fd_p rtol = rtol
+            end
+        end
+    end
+    return fd_u0, fd_p
+end
+
+const CONTINUOUS_SENSEALGS = [
+    "InterpolatingAdjoint" => InterpolatingAdjoint(autojacvec = ReverseDiffVJP()),
+    "InterpolatingAdjoint compiled tape" => InterpolatingAdjoint(
+        autojacvec = ReverseDiffVJP(true)
+    ),
+    "GaussAdjoint" => GaussAdjoint(autojacvec = ReverseDiffVJP()),
+    "QuadratureAdjoint" => QuadratureAdjoint(autojacvec = ReverseDiffVJP()),
+    "BacksolveAdjoint" => BacksolveAdjoint(autojacvec = ReverseDiffVJP()),
+]
+
+@testset "MTK systems with events" begin
+    @testset "Bouncing ball with a symbolic affect" begin
+        @parameters g e
+        @variables h(t) v(t)
+        eqs = [D(h) ~ v, D(v) ~ -g]
+        @mtkcompile ball = System(
+            eqs, t, [h, v], [g, e];
+            continuous_events = [[h ~ 0] => [v ~ -e * Pre(v)]]
+        )
+        prob = ODEProblem{true, SciMLBase.FullSpecialize}(
+            ball, [h => H0, v => V0, g => G0, e => E0], (0.0, 2.0)
+        )
+        idx = variable_index(ball, h)
+
+        # The event has to fire, otherwise the test is vacuous.
+        sol = solve(prob, Tsit5(); saveat = SAVEAT, abstol = ABSTOL, reltol = RELTOL)
+        @test length(sol.t) > length(SAVEAT)
+
+        fd_u0, fd_p = test_event_gradients(
+            prob, idx; sensealgs = CONTINUOUS_SENSEALGS, name = "ball"
+        )
+
+        @testset "ball ForwardDiff" begin
+            fwd = ForwardDiff.gradient(
+                u0 -> sum(
+                    abs2,
+                    Array(
+                        solve(
+                            remake(prob; u0), Tsit5();
+                            saveat = SAVEAT, abstol = ABSTOL, reltol = RELTOL
+                        )
+                    )[idx, :]
+                ),
+                prob.u0
+            )
+            @test fwd ≈ fd_u0 rtol = 1.0e-4
+        end
+
+        @testset "ball EnzymeVJP $sensename" for (sensename, sensealg) in [
+                "InterpolatingAdjoint" => InterpolatingAdjoint(autojacvec = EnzymeVJP()),
+                "GaussAdjoint" => GaussAdjoint(autojacvec = EnzymeVJP()),
+            ]
+            du0 = Zygote.gradient(
+                u0 -> sum(
+                    abs2,
+                    Array(
+                        solve(
+                            remake(prob; u0), Tsit5(); saveat = SAVEAT,
+                            abstol = ABSTOL, reltol = RELTOL, sensealg
+                        )
+                    )[idx, :]
+                ),
+                prob.u0
+            )[1]
+            @test du0 ≈ fd_u0 rtol = 1.0e-4
+        end
+    end
+
+    @testset "Bouncing ball with an ImperativeAffect" begin
+        @parameters g e
+        @variables h(t) v(t)
+        eqs = [D(h) ~ v, D(v) ~ -g]
+        affect = ModelingToolkit.ImperativeAffect(
+            modified = (; v), observed = (; e)
+        ) do m, o, c, i
+            return (; v = -o.e * m.v)
+        end
+        @mtkcompile ball = System(
+            eqs, t, [h, v], [g, e]; continuous_events = [[h ~ 0] => affect]
+        )
+        prob = ODEProblem{true, SciMLBase.FullSpecialize}(
+            ball, [h => H0, v => V0, g => G0, e => E0], (0.0, 2.0)
+        )
+        idx = variable_index(ball, h)
+
+        sol = solve(prob, Tsit5(); saveat = SAVEAT, abstol = ABSTOL, reltol = RELTOL)
+        @test length(sol.t) > length(SAVEAT)
+        test_event_gradients(
+            prob, idx; sensealgs = CONTINUOUS_SENSEALGS[1:3], name = "imperative"
+        )
+    end
+
+    @testset "Affect that changes a parameter" begin
+        # Reference-FMU style: every bounce also damps the restitution. A
+        # parameter written by an affect has to be a discrete parameter, so it
+        # lives in the `Discrete` portion of the parameter object rather than in
+        # the tunable one.
+        @parameters g
+        @discretes e(t) = E0
+        @variables h(t) v(t)
+        eqs = [D(h) ~ v, D(v) ~ -g]
+        @mtkcompile ball = System(
+            eqs, t, [h, v], [g, e];
+            continuous_events = [
+                ModelingToolkit.SymbolicContinuousCallback(
+                    [h ~ 0], [v ~ -Pre(e) * Pre(v), e ~ 0.9 * Pre(e)];
+                    discrete_parameters = [e], iv = t
+                ),
+            ]
+        )
+        prob = ODEProblem{true, SciMLBase.FullSpecialize}(
+            ball, [h => H0, v => V0, g => G0], (0.0, 2.0)
+        )
+        idx = variable_index(ball, h)
+
+        sol = solve(prob, Tsit5(); saveat = SAVEAT, abstol = ABSTOL, reltol = RELTOL)
+        @test length(sol.t) > length(SAVEAT)
+        # `e` is discrete and hence not part of the tunables, but the affect
+        # changing it exercises the non-tunable portions of the parameter object;
+        # the gradients with respect to `u0` and to the tunable `g` must still be
+        # right.
+        fd_u0, _ = test_event_gradients(
+            prob, idx;
+            sensealgs = CONTINUOUS_SENSEALGS[[1, 3]], name = "parameter affect"
+        )
+
+        @testset "parameter affect compiled tape" begin
+            # `ReverseDiffVJP(true)` records the affect tape once, from the last
+            # event. Only the tunables are tape inputs, so the discrete parameter
+            # of that event is baked into the tape as a constant and the earlier
+            # events replay the wrong value. The uncompiled path rebuilds the tape
+            # at every event and is unaffected. Plain-vector parameters are
+            # unaffected too, since there the whole of `p` is a tape input.
+            sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP(true))
+            du0 = Zygote.gradient(
+                u0 -> sum(
+                    abs2,
+                    Array(
+                        solve(
+                            remake(prob; u0), Tsit5(); saveat = SAVEAT,
+                            abstol = ABSTOL, reltol = RELTOL, sensealg
+                        )
+                    )[idx, :]
+                ),
+                prob.u0
+            )[1]
+            @test_broken du0 ≈ fd_u0 rtol = 1.0e-4
+        end
+    end
+
+    @testset "Two events (VectorContinuousCallback)" begin
+        # A ball bouncing between a floor and a ceiling: two continuous events
+        # with the same options compile into one VectorContinuousCallback.
+        @parameters g e
+        @variables h(t) v(t)
+        eqs = [D(h) ~ v, D(v) ~ -g]
+        @mtkcompile ball = System(
+            eqs, t, [h, v], [g, e];
+            continuous_events = [
+                [h ~ 0] => [v ~ -e * Pre(v)],
+                [h ~ 1.5] => [v ~ -e * Pre(v)],
+            ]
+        )
+        prob = ODEProblem{true, SciMLBase.FullSpecialize}(
+            ball, [h => H0, v => 4.0, g => G0, e => E0], (0.0, 2.0)
+        )
+        idx = variable_index(ball, h)
+
+        @test prob.kwargs[:callback] isa VectorContinuousCallback
+        sol = solve(prob, Tsit5(); saveat = SAVEAT, abstol = ABSTOL, reltol = RELTOL)
+        @test length(sol.t) > length(SAVEAT)
+        test_event_gradients(
+            prob, idx; sensealgs = CONTINUOUS_SENSEALGS[1:3], name = "two events"
+        )
+    end
+
+    @testset "Discrete (time-triggered) event" begin
+        @parameters g e
+        @variables h(t) v(t)
+        eqs = [D(h) ~ v, D(v) ~ -g]
+        @mtkcompile ball = System(
+            eqs, t, [h, v], [g, e];
+            continuous_events = [[h ~ 0] => [v ~ -e * Pre(v)]],
+            discrete_events = [1.0 => [v ~ Pre(v) + 0.5]]
+        )
+        prob = ODEProblem{true, SciMLBase.FullSpecialize}(
+            ball, [h => H0, v => V0, g => G0, e => E0], (0.0, 2.0)
+        )
+        idx = variable_index(ball, h)
+
+        test_event_gradients(
+            prob, idx; sensealgs = CONTINUOUS_SENSEALGS[1:3], name = "discrete event"
+        )
+    end
+
+    @testset "adjoint_sensitivities" begin
+        @parameters g e
+        @variables h(t) v(t)
+        eqs = [D(h) ~ v, D(v) ~ -g]
+        @mtkcompile ball = System(
+            eqs, t, [h, v], [g, e];
+            continuous_events = [[h ~ 0] => [v ~ -e * Pre(v)]]
+        )
+        prob = ODEProblem{true, SciMLBase.FullSpecialize}(
+            ball, [h => H0, v => V0, g => G0, e => E0], (0.0, 2.0)
+        )
+        idx = variable_index(ball, h)
+        sensealg = InterpolatingAdjoint(autojacvec = ReverseDiffVJP())
+        ts = collect(SAVEAT)
+        dgdu = (out, u, p, tt, i) -> (out .= 0; out[idx] = 2u[idx]; nothing)
+
+        @testset "untracked callbacks are rejected" begin
+            sol = solve(
+                prob, Tsit5(); saveat = SAVEAT, abstol = ABSTOL, reltol = RELTOL
+            )
+            @test_throws ArgumentError adjoint_sensitivities(
+                sol, Tsit5(); t = ts, sensealg, dgdu_discrete = dgdu
+            )
+        end
+
+        @testset "tracked callbacks are picked up from the problem" begin
+            cb = SciMLSensitivity.track_callbacks(
+                prob.kwargs[:callback], prob.tspan[1], prob.u0, prob.p, sensealg
+            )
+            _prob = remake(prob; kwargs = merge(values(prob.kwargs), (; callback = cb)))
+            # A dense forward solution: a `saveat`-only one makes the adjoint fall
+            # back to checkpointing, whose event handling is inaccurate for plain
+            # vectors as well.
+            sol = solve(
+                _prob, Tsit5(); save_everystep = true, abstol = ABSTOL, reltol = RELTOL
+            )
+            du0, dp = adjoint_sensitivities(
+                sol, Tsit5(); t = ts, sensealg, dgdu_discrete = dgdu
+            )
+
+            lossu0(u0) = sum(
+                abs2,
+                Array(
+                    solve(
+                        remake(prob; u0), Tsit5();
+                        saveat = SAVEAT, abstol = ABSTOL, reltol = RELTOL
+                    )
+                )[idx, :]
+            )
+            @test du0 ≈ FiniteDiff.finite_difference_gradient(lossu0, prob.u0) rtol = 1.0e-4
+
+            zy = Zygote.gradient(
+                u0 -> sum(
+                    abs2,
+                    Array(
+                        solve(
+                            remake(prob; u0), Tsit5(); saveat = SAVEAT,
+                            abstol = ABSTOL, reltol = RELTOL, sensealg
+                        )
+                    )[idx, :]
+                ),
+                prob.u0
+            )[1]
+            @test du0 ≈ zy rtol = 1.0e-6
+        end
+    end
+
+    @testset "Plain vector parameters are unchanged" begin
+        # Regression guard for the array fast paths, adapted from
+        # test/Callbacks2/continuous_callbacks.jl.
+        N0 = [0.0]
+        p = [100.0, 50.0]
+        tspan = (0.0, 10.0)
+
+        f(D, u, p, t) = (D[1] = p[1] - u[1])
+        condition(u, t, integrator) = u[1] - 3 // 4 * integrator.p[1]
+        affect!(integrator) = integrator.u[1] += integrator.p[2]
+        cb = ContinuousCallback(condition, affect!, save_positions = (false, false))
+        prob = ODEProblem(f, N0, tspan, p)
+
+        function loss(p, sensealg)
+            _prob = remake(prob; p)
+            _sol = solve(
+                _prob, Tsit5(); callback = cb, abstol = 1.0e-14, reltol = 1.0e-14,
+                sensealg
+            )
+            return _sol.u[end][1]
+        end
+
+        gFD = ForwardDiff.gradient(p -> loss(p, nothing), p)
+        @testset "plain vector $i" for (i, sensealg) in enumerate(
+                [
+                    InterpolatingAdjoint(autojacvec = ReverseDiffVJP()),
+                    InterpolatingAdjoint(autojacvec = ReverseDiffVJP(true)),
+                    GaussAdjoint(autojacvec = ReverseDiffVJP()),
+                    InterpolatingAdjoint(autojacvec = EnzymeVJP()),
+                ]
+            )
+            @test gFD ≈ Zygote.gradient(p -> loss(p, sensealg), p)[1] rtol = 1.0e-10
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,6 +109,7 @@ run_tests(;
                 @time @safetestset "Adjoints through NonlinearProblem" include("Core8/parameter_initialization.jl")
                 @time @safetestset "Initialization with MTK" include("Core8/desauty_dae_mwe.jl")
                 @time @safetestset "MTK Forward Mode" include("Core8/mtk.jl")
+                @time @safetestset "MTK Events Adjoint" include("Core8/mtk_events.jl")
                 @time @safetestset "SCCNonlinearProblem" include("Core8/scc_nonlinearsolve.jl")
                 @time @safetestset "EnzymeVJP Repeated Adjoint" include("Core8/enzyme_vjp_repeated_adjoint.jl")
             end


### PR DESCRIPTION
Fixes the SciMLSensitivity side of SciML/ModelingToolkit.jl#5018 (companion: SciML/ModelingToolkit.jl#5042, required by the new tests).

The callback VJP path assumed `p` is a plain `Vector`; it now goes through SciMLStructures for structured parameters (plain arrays unchanged), `FakeIntegrator` implements the SymbolicIndexingInterface accessors, tracked callbacks keep the newer SciMLBase fields, `reset_p` accepts a bare callback, and `adjoint_sensitivities` uses the problem's callbacks when tracked or throws an explanatory `ArgumentError` when not (instead of a `FieldError` or a silently uncorrected gradient).

Tested: new `test/Core8/mtk_events.jl` (47 pass, 1 `@test_broken`: compiled ReverseDiff tape with an affect writing a non-tunable parameter); `Callbacks1` 361/361, `Callbacks2` 211/211. Core8 needs the MTK companion released; compat bump to follow.