### PR TITLE
Fix matrix parameter Zygote VJPs

### DIFF
--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -847,6 +847,8 @@ function _vecjacobian!(
         else
             tunables, repack = p, identity
         end
+    elseif p isa AbstractArray
+        tunables, repack = p, identity
     else
         (; tunables, repack) = S.diffcache
     end

--- a/test/Core1/scimlstructures_interface.jl
+++ b/test/Core1/scimlstructures_interface.jl
@@ -1,5 +1,5 @@
 # taken from https://github.com/SciML/SciMLStructures.jl/pull/28
-using OrdinaryDiffEq, SciMLSensitivity, Zygote
+using OrdinaryDiffEq, SciMLSensitivity, Zygote, ForwardDiff
 using LinearAlgebra
 import SciMLStructures as SS
 
@@ -246,3 +246,20 @@ end
         QuadratureAdjoint(autojacvec = MooncakeVJP())
     )[1].ps
 )
+
+@testset "Matrix parameter ZygoteVJP" begin
+    p_matrix = [0.1 0.2; -0.3 0.4]
+    matrix_prob = ODEProblem((u, p, t) -> p * u, [1.0, -1.0], (0.0, 0.5), p_matrix)
+    function matrix_loss(p, sensealg = nothing)
+        sol = solve(matrix_prob, Tsit5(); p, sensealg, saveat = 0.5)
+        return sum(abs2, sol.u[end])
+    end
+
+    grad = Zygote.gradient(
+        p -> matrix_loss(p, BacksolveAdjoint(autojacvec = ZygoteVJP())), p_matrix
+    )[1]
+    reference = ForwardDiff.gradient(
+        p -> matrix_loss(reshape(p, size(p_matrix))), vec(p_matrix)
+    )
+    @test vec(grad) ≈ reference rtol = 1.0e-6
+end


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Preserve an `AbstractArray` parameter's shape when Zygote computes parameter VJPs instead of canonicalizing it to a flat tunables vector and reconstructing it inside every VJP. The canonicalize/repack route exposes an incorrect `ArrayInterface.restructure` pullback for matrix parameters: the forward function receives the matrix, but the pullback projects the flat cotangent to the matrix shape and throws `DimensionMismatch`. Structured non-array parameters continue to use the existing cached SciMLStructures canonicalization.

Besides fixing matrix parameters, this removes the per-VJP repack for ordinary arrays. On a 16×32 matrix, the isolated repack operation allocated 48 bytes while the identity path allocated 0 bytes.

## Failing before / passing after

The added CPU regression exercises the same BacksolveAdjoint + ZygoteVJP matrix-parameter path as the current GPU failure, so it can be validated without CUDA hardware.

On the unfixed code, the regression failed with:

```text
ERROR: DimensionMismatch: variable with size(x) == (2, 2) cannot have a gradient with size(dx) == (4,)
...
src/derivative_wrappers.jl:895
```

With this commit, the same calculation passes and agrees with ForwardDiff:

```text
gradient=[1.0316231482369491 -1.252412209822305; -1.4304192821938633 1.7440303280389502]
reference=[1.0316231436844971, -1.4304192761411767, -1.2524122141938625, 1.744030329892321]
relative_error=4.4129021327423305e-9
```

## Verification

```text
$ GROUP=QA julia +release --project=. -e 'using Pkg; Pkg.test()'
Test Summary:     | Pass  Total     Time
Quality Assurance |   20     20  3m10.0s
Testing SciMLSensitivity tests passed

$ julia +release -e 'using Runic; exit(Runic.main(ARGS))' -- --check src/derivative_wrappers.jl test/Core1/scimlstructures_interface.jl
[exit 0]

$ typos src/derivative_wrappers.jl test/Core1/scimlstructures_interface.jl
[exit 0]

$ git diff --check
[exit 0]
```

The first full `GROUP=Core1` attempt reached no assertion failure but hit the one-hour external timeout during the pre-existing, compilation-heavy `concrete_solve_derivatives.jl` tests. A warmed-cache rerun remained CPU-bound in that group with completed testsets reporting 96–100% compilation; the focused regression above was rerun successfully after rebasing on current `upstream/master`.

## Not verified locally

The exact CUDA test could not be rerun because this host has no NVIDIA device (`nvidia-smi` is unavailable and `/dev/nvidia*` is absent). The current master GPU run and the originating PR run show the identical pre-existing matrix `(16, 32)` / gradient `(512,)` failure, followed by CUDA's scalar-indexing rejection in the fallback path.

The underlying `ArrayInterface.restructure` ChainRules rule appears to have introduced the shape mismatch by using `ProjectTo(target)` instead of `ProjectTo(src)`. A standalone environment importing no SciML package reproduced that defect with ArrayInterface 7.30.0, Zygote 0.7.12, ChainRulesCore 1.26.1, and Julia 1.12.6. This PR applies the narrower SciMLSensitivity-side fix and does not modify upstream ArrayInterface.

No docs build was run because this changes neither documentation nor public API. GPU and downstream jobs were not run locally.

## Links

- Master GPU failure: https://github.com/SciML/SciMLSensitivity.jl/actions/runs/33287673233/job/99193613593
- Originating PR GPU failure: https://github.com/SciML/SciMLSensitivity.jl/actions/runs/33296427890/job/99216774312
- SciMLSensitivity canonicalization change: https://github.com/SciML/SciMLSensitivity.jl/commit/e46940598cd4b2557609280973593304421ba4e5
- ArrayInterface rrule introduction: https://github.com/JuliaArrays/ArrayInterface.jl/commit/c7216c3241346d550f3ac2a4fe0211161e268ffe

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5; session: local session ID `01a04f97-3c62-78d2-9e52-c1ed0aa80b23`)
