### PR TITLE
Preserve Tracker array parameter gradients

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -2045,6 +2045,8 @@ function SciMLBase._concrete_solve_adjoint(
 
     if p === nothing || p isa SciMLBase.NullParameters
         tunables, repack = p, identity
+    elseif p isa AbstractArray
+        tunables, repack = p, identity
     else
         tunables, repack, _ = canonicalize(Tunable(), p)
     end
@@ -2117,7 +2119,7 @@ function SciMLBase._concrete_solve_adjoint(
                             _g
                         ),
                         g = _g,
-                        u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p),
+                        u0 = _u0, p = repack(_p),
                         tspan = _tspan, callback = nothing
                     )
                 else
@@ -2127,7 +2129,7 @@ function SciMLBase._concrete_solve_adjoint(
                             false,
                             SciMLBase.FullSpecialize,
                         }(_f),
-                        u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p),
+                        u0 = _u0, p = repack(_p),
                         tspan = _tspan, callback = nothing
                     )
                 end
@@ -2160,7 +2162,7 @@ function SciMLBase._concrete_solve_adjoint(
                             _g
                         ),
                         g = _g,
-                        u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p),
+                        u0 = _u0, p = repack(_p),
                         tspan = _tspan, callback = nothing
                     )
                 else
@@ -2170,7 +2172,7 @@ function SciMLBase._concrete_solve_adjoint(
                             false,
                             SciMLBase.FullSpecialize,
                         }(_f),
-                        u0 = _u0, p = SciMLStructures.replace(Tunable(), p, _p),
+                        u0 = _u0, p = repack(_p),
                         tspan = _tspan, callback = nothing
                     )
                 end


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Keep `AbstractArray` parameters in their original shape when `TrackerAdjoint` records its forward pass, and use the `repack` function returned by `canonicalize` for structured non-array parameters. This prevents ArrayInterface's GPU-array restructure path from adapting a `Tracker.TrackedArray` into an untracked device array, which silently makes the parameter gradient zero.

This is separate from the ZygoteVJP fix in https://github.com/SciML/SciMLSensitivity.jl/pull/1633: it affects the outer `TrackerAdjoint` tape in `concrete_solve.jl`, while that PR affects inner Zygote vector-Jacobian products in `derivative_wrappers.jl`.

## Failing before / passing after

The GPU regression added by https://github.com/SciML/SciMLSensitivity.jl/pull/1630 failed in that PR's own GPU job and again on current master. For both save configurations, `du0` passed but `dp` was zero:

```text
Evaluated: Float32[0.0, 0.0] ≈ Float32[1.105171, 1.105171] (rtol=0.001)
TrackerAdjoint DiffEqArray | 2 passed, 2 failed
```

A device-independent JLArray reproduction exercises the same GPUArraysCore dispatch. On the unfixed source:

```text
kwargs=(save_everystep = false, save_start = false) du0=Float32[1.105171, 1.105171] dp=Float32[0.0, 0.0]
kwargs=(saveat = 0.1f0,) du0=Float32[1.105171, 1.105171] dp=Float32[0.0, 0.0]
```

With this commit, the same reproduction passes:

```text
kwargs=(save_everystep = false, save_start = false) du0=Float32[1.105171, 1.105171] dp=Float32[1.1051711, 1.1051711] expected=Float32[1.105171, 1.105171]
kwargs=(saveat = 0.1f0,) du0=Float32[1.105171, 1.105171] dp=Float32[1.1051711, 1.1051711] expected=Float32[1.105171, 1.105171]
```

The existing CPU Array equivalent also passes with the same values for both `du0` and `dp`.

## Root cause

`e838a6c3697b5071e72b2b425ea63de478a60dac` changed `TrackerAdjoint` from recording the original `p` to recording `canonicalize(Tunable(), p)[1]`. For an array this is a flattened buffer, so reconstructing a GPUArraysCore array invokes `ArrayInterface.restructure(target, tracked_source)`. A standalone environment importing no SciML package reproduced the loss of tracking with ArrayInterface 7.30.0, JLArrays 0.3.3, and Tracker 0.2.39:

```text
forward=21.0f0 (tracked)
gradient_type=JLArray{Float32, 1}
gradient=Float32[0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
```

Using the identity path preserves the `TrackedArray` and returns all-one gradients. For a warmed 16×32 tracked JLArray, restructure allocated 128,864 bytes while identity allocated 0 bytes.

## Verification

```text
$ GROUP=QA timeout 3600 julia +release --project=. -e 'using Pkg; Pkg.test()'
Test Summary:     | Pass  Total     Time
Quality Assurance |   20     20  3m15.4s
Testing SciMLSensitivity tests passed

$ julia +release -e 'using Runic; exit(Runic.main(ARGS))' -- --check src/concrete_solve.jl
[exit 0]

$ typos src/concrete_solve.jl
[exit 0]

$ git diff --check
[exit 0]
```

## CI verification

The V100 workflow on this commit verifies the exact `CuArray` regression path:

```text
Test Summary:                | Pass  Error  Total      Time
GPU                          |    5      1      6  10m42.8s
  Mixed GPU/CPU              |    1      1      2   1m04.6s
  TrackerAdjoint DiffEqArray |    4             4      23.1s
```

V100 job: https://github.com/SciML/SciMLSensitivity.jl/actions/runs/33310795928/job/99255355741

The target test is therefore passing after the fix. The job remains red only because the separate mixed GPU/CPU test reaches ForwardDiff's known GPU scalar-indexing bug in `_seed_zero_partials!`; its upstream fix is https://github.com/JuliaDiff/ForwardDiff.jl/pull/816.

The ordinary Core1 jobs pass on Julia latest and 1.11:

- https://github.com/SciML/SciMLSensitivity.jl/actions/runs/33310796277/job/99268585038
- https://github.com/SciML/SciMLSensitivity.jl/actions/runs/33310796277/job/99268585060

The other red jobs reproduce failures already established on unmodified master: downgrade and Julia LTS Core1 hit the Mooncake HVP regression tracked at https://github.com/SciML/SciMLSensitivity.jl/issues/1632, while QA hit Aqua's persistent-task `done.log` race tracked at https://github.com/SciML/SciMLSensitivity.jl/issues/1554. A separate isolated local QA rerun passed 20/20 in 4m35.0s.

Additional CI audit and isolated QA validation were performed with Codex CLI 0.151.0 (model: gpt-5.6-sol; session transcript: `/home/crackauc/.codex/sessions/2026/08/29/rollout-2026-08-29T20-41-15-01a0501d-0879-7f80-b479-de442568c09d.jsonl`).

## Not verified locally

The exact CUDA test was not run locally because this host has no NVIDIA device (`nvidia-smi` is unavailable and `/dev/nvidia*` is absent). The existing GPU test is unchanged and is the CI verification for the exact CuArray path. No docs build was run because this changes neither documentation nor public API; downstream jobs were not run locally.

## Links

- Current master reproduction: https://github.com/SciML/SciMLSensitivity.jl/actions/runs/33303358587/job/99235435055
- Original fix PR: https://github.com/SciML/SciMLSensitivity.jl/pull/1630
- Original fix PR's failing GPU job: https://github.com/SciML/SciMLSensitivity.jl/actions/runs/33301655137/job/99230855733
- Introducing Tracker canonicalization commit: https://github.com/SciML/SciMLSensitivity.jl/commit/e838a6c3697b5071e72b2b425ea63de478a60dac
- Related but separate ZygoteVJP fix: https://github.com/SciML/SciMLSensitivity.jl/pull/1633

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5; session: local session ID `01a04f97-3c62-78d2-9e52-c1ed0aa80b23`)