### PR TITLE
Add 32-bit Core1 CI lane via test_groups.toml

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,6 +1,12 @@
 [Core1]
 versions = ["1", "1.11", "lts"]
 
+["Core1 32-bit"]
+group = "Core1"
+versions = ["1"]
+os = ["ubuntu-latest"]
+arch = "x86"
+
 [Core2]
 versions = ["1", "1.11", "lts"]
 


### PR DESCRIPTION

## Summary
- Add a `["Core1 32-bit"]` matrix-only alias (`group = "Core1"`, `arch = "x86"`, Linux only) so this package exercises 32-bit Julia via SciML/.github `@v1`.
- No `[Core]` group in this matrix; alias targets the primary `Core1` lane.

## Test plan
- [ ] CI shows a job with `, x86)` for this group
- [ ] Job green, or failure is a real Int32/WordSize bug to fix
