### PR TITLE
Keep the DAE adjoint in residual form when no algorithm is given

### DIFF
--- a/src/dae_adjoint.jl
+++ b/src/dae_adjoint.jl
@@ -266,8 +266,8 @@ adjoint state is `z = [w; λ]` with `w = (∂F/∂(du))' λ` (plus the parameter
 quadrature block for `InterpolatingAdjoint`). The returned problem is a
 singular-mass-matrix `ODEProblem` when `alg` is a mass-matrix-capable stiff ODE
 solver (e.g. `FBDF`, `Rodas5P`), or a fully implicit `DAEProblem` when `alg` is a
-DAE solver (e.g. `DFBDF`), solved backwards in time. When `alg` is `nothing` the
-algorithm of the forward solution decides, so a forward solve with the default DAE
+DAE solver (e.g. `DFBDF`), solved backwards in time. When `alg` is `nothing`, the
+algorithm of the forward solution is used, so a forward solve with the default DAE
 algorithm gets a `DAEProblem`.
 
 The arguments mirror `ODEAdjointProblem`, with methods for `InterpolatingAdjoint`,
@@ -380,9 +380,9 @@ function _dae_adjoint_problem(
         )
         error("Callbacks are not currently supported for DAEProblem adjoints.")
     end
-    # No algorithm means the forward solve used the default DAE algorithm; keep the adjoint in
-    # residual form for it. The mass-matrix form under the default ODE algorithm rebuilds its
-    # Jacobian at every step and does not finish on moderately sized problems.
+    # With no algorithm given, take the one of the forward solve. This keeps the adjoint of a
+    # `solve(prob)` without an algorithm in residual form: its mass-matrix form under the default
+    # ODE algorithm rebuilds the Jacobian at every step and does not finish at a few dozen states.
     alg === nothing && (alg = sol.alg)
 
     (; tspan) = sol.prob

--- a/src/dae_adjoint.jl
+++ b/src/dae_adjoint.jl
@@ -266,7 +266,9 @@ adjoint state is `z = [w; λ]` with `w = (∂F/∂(du))' λ` (plus the parameter
 quadrature block for `InterpolatingAdjoint`). The returned problem is a
 singular-mass-matrix `ODEProblem` when `alg` is a mass-matrix-capable stiff ODE
 solver (e.g. `FBDF`, `Rodas5P`), or a fully implicit `DAEProblem` when `alg` is a
-DAE solver (e.g. `DFBDF`), solved backwards in time.
+DAE solver (e.g. `DFBDF`), solved backwards in time. When `alg` is `nothing` the
+algorithm of the forward solution decides, so a forward solve with the default DAE
+algorithm gets a `DAEProblem`.
 
 The arguments mirror `ODEAdjointProblem`, with methods for `InterpolatingAdjoint`,
 `QuadratureAdjoint`, and `GaussAdjoint`/`GaussKronrodAdjoint` (which mirrors the
@@ -378,6 +380,10 @@ function _dae_adjoint_problem(
         )
         error("Callbacks are not currently supported for DAEProblem adjoints.")
     end
+    # No algorithm means the forward solve used the default DAE algorithm; keep the adjoint in
+    # residual form for it. The mass-matrix form under the default ODE algorithm rebuilds its
+    # Jacobian at every step and does not finish on moderately sized problems.
+    alg === nothing && (alg = sol.alg)
 
     (; tspan) = sol.prob
     p = parameter_values(sol.prob)

--- a/test/Core3/dae_adjoint.jl
+++ b/test/Core3/dae_adjoint.jl
@@ -339,16 +339,15 @@ end
 end
 
 @testset "no algorithm: adjoint in residual form" begin
-    # The heat equation on a grid with the Dirichlet values as algebraic rows, the layout a PDE
+    # Diffusion with decay on a grid, the Dirichlet values as algebraic rows: the layout a PDE
     # discretization produces. Solved without an algorithm, the adjoint must stay in residual
-    # form: its mass-matrix form under the default ODE algorithm does not finish at this size.
+    # form; its mass-matrix form under the default ODE algorithm does not finish at this size.
     n = 26
     h = 1 / (n - 1)
     function heat_dae!(res, du, u, p, t)
-        a = p[1] + p[2]
         res[1] = u[1] - exp(-t)
         for i in 2:(n - 1)
-            res[i] = a * (u[i - 1] - 2u[i] + u[i + 1]) / h^2 - du[i]
+            res[i] = p[1] * (u[i - 1] - 2u[i] + u[i + 1]) / h^2 - p[2] * u[i] - du[i]
         end
         res[n] = u[n] - exp(-t) * cos(1)
         return nothing

--- a/test/Core3/dae_adjoint.jl
+++ b/test/Core3/dae_adjoint.jl
@@ -1,5 +1,6 @@
 using OrdinaryDiffEq, SciMLSensitivity, ForwardDiff, Zygote, SciMLBase, Test
 using OrdinaryDiffEqBDF: DFBDF, DImplicitEuler
+using OrdinaryDiffEqNonlinearSolve: BrownFullBasicInit
 
 # Fully implicit DAEProblem adjoints via the augmented adjoint DAE
 # (Cao, Li, Petzold & Serban, SIAM Journal on Scientific Computing 24(3), 2003).
@@ -335,4 +336,42 @@ end
             autojacvec = ReverseDiffVJP(), checkpointing = true
         )
     )
+end
+
+@testset "no algorithm: adjoint in residual form" begin
+    # The heat equation on a grid with the Dirichlet values as algebraic rows, the layout a PDE
+    # discretization produces. Solved without an algorithm, the adjoint must stay in residual
+    # form: its mass-matrix form under the default ODE algorithm does not finish at this size.
+    n = 26
+    h = 1 / (n - 1)
+    function heat_dae!(res, du, u, p, t)
+        a = p[1] + p[2]
+        res[1] = u[1] - exp(-t)
+        for i in 2:(n - 1)
+            res[i] = a * (u[i - 1] - 2u[i] + u[i + 1]) / h^2 - du[i]
+        end
+        res[n] = u[n] - exp(-t) * cos(1)
+        return nothing
+    end
+    p = [1.2, 2.1]
+    u0 = cos.(range(0, 1; length = n))
+    prob = DAEProblem(
+        heat_dae!, zeros(n), u0, (0.0, 1.0), p;
+        differential_vars = [false; trues(n - 2); false]
+    )
+    kw = (; abstol = 1.0e-8, reltol = 1.0e-8, initializealg = BrownFullBasicInit())
+    sol = solve(prob; kw...)
+    @test sol.alg isa DFBDF
+    ts = collect(0.0:0.1:1.0)
+    sensealg = InterpolatingAdjoint(autojacvec = false)
+    @test SciMLSensitivity.DAEAdjointProblem(sol, sensealg, nothing, ts, sumsq_dg) isa DAEProblem
+    dp_default = adjoint_sensitivities(
+        sol, nothing; t = ts, dgdu_discrete = sumsq_dg, sensealg, abstol = 1.0e-8, reltol = 1.0e-8
+    )[2]
+    dp_dfbdf = adjoint_sensitivities(
+        sol, DFBDF(); t = ts, dgdu_discrete = sumsq_dg, sensealg, abstol = 1.0e-8, reltol = 1.0e-8
+    )[2]
+    @test dp_default ≈ dp_dfbdf rtol = 1.0e-6
+    loss(p) = sum(sum(abs2, u) / 2 for u in solve(remake(prob; p); saveat = ts, sensealg, kw...).u)
+    @test Zygote.gradient(loss, p)[1] ≈ ForwardDiff.gradient(loss, p) rtol = 1.0e-5
 end


### PR DESCRIPTION
`DAEAdjointProblem` builds the augmented adjoint as a fully implicit `DAEProblem` when `alg` is a DAE algorithm and as a mass-matrix `ODEProblem` otherwise. A forward `solve(prob)` without an algorithm passes `alg = nothing` through the sensitivity rules, so the adjoint of a `DAEProblem` solved with the default DAE algorithm lands in the mass-matrix form and is handed to the default ODE algorithm. That solve rebuilds its Jacobian at every step: on a 26-state diffusion-decay DAE with the Dirichlet values as algebraic rows (54 adjoint states) it does not return within 30 minutes, while the same adjoint in residual form takes 0.2 s with `DFBDF`.

With no algorithm, the adjoint now takes the algorithm of the forward solution, so it stays in residual form and the reverse solve gets the default DAE algorithm, as the forward solve did.

Measured on that DAE, `InterpolatingAdjoint(autojacvec = false)`, `Zygote.gradient` through `solve`, second call:

| states | `solve(prob, DFBDF())` | `solve(prob)` before | `solve(prob)` after |
|---:|---:|---:|---:|
| 11 | 0.05 s | 0.21 s (545 steps, 572 Jacobians, 19k rhs calls) | 0.14 s (2513 steps, 1 Jacobian) |
| 26 | 0.24 s | not returned after 30 min | 0.13 s (3610 steps, 1 Jacobian) |

Test: the adjoint problem built with `alg = nothing` is a `DAEProblem`, its gradient matches the explicit `DFBDF()` one, and the Zygote gradient through `solve` without an algorithm matches ForwardDiff, on that 26-state DAE.