### PR TITLE
Differentiate the bare rhs in `EnzymeVJP`, not the `ODEFunction` container

### DIFF
--- a/src/SciMLSensitivity.jl
+++ b/src/SciMLSensitivity.jl
@@ -43,7 +43,7 @@ using SciMLBase: SciMLBase, AbstractOverloadingSensitivityAlgorithm,
     SDEProblem, VectorContinuousCallback,
     get_tmp_cache, isinplace, reinit!, remake,
     solve, derivative_discontinuity!, LinearAliasSpecifier, OverrideInit, AbstractOptimizationProblem
-using SciMLOperators: has_adjoint
+using SciMLOperators: SciMLOperators, has_adjoint
 
 using OrdinaryDiffEqCore: OrdinaryDiffEqCore, BrownFullBasicInit, DefaultInit,
     default_nlsolve, has_autodiff

--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -286,7 +286,8 @@ function adjointdiffcache(
         pf = nothing
     elseif autojacvec isa EnzymeVJP
         paramjac_config = get_paramjac_config(autojacvec, p, f, y, _p, _t; numindvar, alg)
-        pf = get_pf(autojacvec; _f = unwrappedf, isinplace, isRODE)
+        # must match the primal `_vecjacobian!(::EnzymeVJP)` differentiates
+        pf = get_pf(autojacvec; _f = enzyme_rhs(unwrappedf), isinplace, isRODE)
         if isDAE
             # The residual takes `du` as an extra differentiated argument; append
             # its primal and shadow buffers to the standard Enzyme config.
@@ -752,6 +753,22 @@ function get_pf(
     )
     return nothing
 end
+
+"""
+    enzyme_rhs(f)
+
+The function the Enzyme VJPs differentiate. They only ever *call* the right-hand
+side, so for an `ODEFunction` this is the bare user function rather than the
+container. The container also carries `sys`, `observed`, `initialization_data`,
+... which Enzyme cannot prove derivative-free (e.g. the `Dict{SymbolicT, SymbolicT}`
+maps in ModelingToolkit's `InitializationMetadata`), so differentiating it means
+allocating a shadow of all of that and `remake_zero!`-ing it on every VJP call:
+for an MTK-generated 32-state linear ODE ~190 µs per call against a ~5 ns rhs,
+making `GaussAdjoint(EnzymeVJP)` gradients ~8x slower than necessary.
+`DAEFunction`s already get this treatment through `dae_unwrapped_f`.
+"""
+enzyme_rhs(f) = f
+enzyme_rhs(f::ODEFunction) = unwrapped_f(f.f)
 
 function get_pf(autojacvec::EnzymeVJP; _f, isinplace, isRODE)
     return isinplace ? SciMLBase.Void(_f) : _f

--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -777,7 +777,7 @@ sees matching types; any new method here has to be audited against every such pa
 """
 enzyme_rhs(f) = unwrapped_f(f)
 function enzyme_rhs(f::ODEFunction)
-    f.f isa SciMLBase.AbstractSciMLOperator && return unwrapped_f(f)
+    f.f isa SciMLOperators.AbstractSciMLOperator && return unwrapped_f(f)
     return unwrapped_f(f.f)
 end
 

--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -766,9 +766,20 @@ allocating a shadow of all of that and `remake_zero!`-ing it on every VJP call:
 for an MTK-generated 32-state linear ODE ~190 µs per call against a ~5 ns rhs,
 making `GaussAdjoint(EnzymeVJP)` gradients ~8x slower than necessary.
 `DAEFunction`s already get this treatment through `dae_unwrapped_f`.
+
+An `ODEFunction` whose `f.f` is an `AbstractSciMLOperator` is kept whole: its call
+`f(du, u, p, t)` forwards as `f.f(du, u, u, p, t)`, which the bare operator would not.
+
+Contract: the shadow is built at configuration time and the primal at call time,
+in different places (`adjointdiffcache`/`_vecjacobian!`, the Gauss and Quadrature
+integrands). Both sides must go through `enzyme_rhs` so `Duplicated(primal, shadow)`
+sees matching types; any new method here has to be audited against every such pair.
 """
-enzyme_rhs(f) = f
-enzyme_rhs(f::ODEFunction) = unwrapped_f(f.f)
+enzyme_rhs(f) = unwrapped_f(f)
+function enzyme_rhs(f::ODEFunction)
+    f.f isa SciMLBase.AbstractSciMLOperator && return unwrapped_f(f)
+    return unwrapped_f(f.f)
+end
 
 function get_pf(autojacvec::EnzymeVJP; _f, isinplace, isRODE)
     return isinplace ? SciMLBase.Void(_f) : _f

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -1016,8 +1016,9 @@ function _vecjacobian!(
     du === nothing ||
         return _dae_vecjacobian!(dλ, y, λ, p, t, S, isautojacvec, dgrad, dy, W, du, ddu)
     (; sensealg) = S
-    # the bare rhs, matching the shadow built in `adjointdiffcache` (see `enzyme_rhs`)
-    f = enzyme_rhs(unwrapped_f(S.f))
+    # the bare rhs, matching the shadow built in `adjointdiffcache` (see `enzyme_rhs`);
+    # `enzyme_rhs` unwraps itself, so no per-call container rebuild here
+    f = enzyme_rhs(S.f)
 
     prob = getprob(S)
 
@@ -1155,20 +1156,35 @@ function _vecjacobian!(
         end
         dy !== nothing && recursive_copyto!(dy, tmp3)
     else
+        # Out-of-place. Reuse the shadow cached in `adjointdiffcache` when it was
+        # built for this very function (both sides go through `enzyme_rhs`), else
+        # fall back to a fresh `make_zero`. A function without differentiable
+        # state — a ghost/singleton, or one for which `make_zero` hands back the
+        # primal (e.g. a bare MTK rhs once the container is peeled) — must be
+        # passed `Const`: Enzyme rejects `Duplicated` for ghost types.
+        shadow = if _tmp6 !== f && typeof(_tmp6) === typeof(f)
+            Enzyme.remake_zero!(_tmp6)
+            _tmp6
+        else
+            Enzyme.make_zero(f)
+        end
+        fdup = if shadow === f || Base.issingletontype(typeof(f))
+            Enzyme.Const(f)
+        else
+            Enzyme.Duplicated(f, shadow)
+        end
         if W === nothing
-            _tmp6 = Enzyme.make_zero(f)
             Enzyme.autodiff(
                 enzyme_mode, Enzyme.Const(gclosure1), Enzyme.Const,
-                Enzyme.Duplicated(f, _tmp6),
+                fdup,
                 Enzyme.Duplicated(tmp3, tmp4),
                 Enzyme.Duplicated(ytmp, tmp1),
                 dup, Enzyme.Const(t)
             )
         else
-            _tmp6 = Enzyme.make_zero(f)
             Enzyme.autodiff(
                 enzyme_mode, Enzyme.Const(gclosure2), Enzyme.Const,
-                Enzyme.Duplicated(f, _tmp6),
+                fdup,
                 Enzyme.Duplicated(tmp3, tmp4),
                 Enzyme.Duplicated(ytmp, tmp1),
                 dup, Enzyme.Const(t), Enzyme.Const(W)

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -1016,7 +1016,8 @@ function _vecjacobian!(
     du === nothing ||
         return _dae_vecjacobian!(dλ, y, λ, p, t, S, isautojacvec, dgrad, dy, W, du, ddu)
     (; sensealg) = S
-    f = unwrapped_f(S.f)
+    # the bare rhs, matching the shadow built in `adjointdiffcache` (see `enzyme_rhs`)
+    f = enzyme_rhs(unwrapped_f(S.f))
 
     prob = getprob(S)
 
@@ -1113,11 +1114,22 @@ function _vecjacobian!(
     enzyme_mode = isautojacvec.mode
 
     if inplace_sensitivity(S)
-        Enzyme.remake_zero!(_tmp6)
+        vf = SciMLBase.Void(f)
+        # `make_zero` hands the primal itself back when the function carries no
+        # differentiable state (a singleton, or e.g. an MTK generated-function
+        # wrapper once the `ODEFunction` container is peeled off by `enzyme_rhs`).
+        # Enzyme then needs no shadow at all, so pass the function `Const` and skip
+        # the per-call `remake_zero!`; only genuinely stateful closures pay for it.
+        fdup = if _tmp6 === vf || Base.issingletontype(typeof(vf))
+            Enzyme.Const(vf)
+        else
+            Enzyme.remake_zero!(_tmp6)
+            Enzyme.Duplicated(vf, _tmp6)
+        end
 
         if W === nothing
             Enzyme.autodiff(
-                enzyme_mode, Enzyme.Duplicated(SciMLBase.Void(f), _tmp6),
+                enzyme_mode, fdup,
                 Enzyme.Const, Enzyme.Duplicated(tmp3, tmp4),
                 Enzyme.Duplicated(ytmp, tmp1),
                 dup,
@@ -1125,7 +1137,7 @@ function _vecjacobian!(
             )
         else
             Enzyme.autodiff(
-                enzyme_mode, Enzyme.Duplicated(SciMLBase.Void(f), _tmp6),
+                enzyme_mode, fdup,
                 Enzyme.Const, Enzyme.Duplicated(tmp3, tmp4),
                 Enzyme.Duplicated(ytmp, tmp1),
                 dup,

--- a/src/gauss_adjoint.jl
+++ b/src/gauss_adjoint.jl
@@ -501,13 +501,17 @@ function GaussIntegrand(sol, sensealg, checkpoints, dgdp = nothing)
         # `p` (e.g. MTKParameters) and a flat-vector shadow `out`, which has no
         # matching `Enzyme.Duplicated` constructor.
         _needs_repack = isscimlstructure(p) && !(p isa AbstractArray)
+        # Differentiate the bare rhs (see `enzyme_rhs`): with the `ODEFunction`
+        # container captured here, `make_zero(pf)` shadows `sys`/`observed`/
+        # `initialization_data` too and `vec_pjac!` re-zeroes all of it on every
+        # quadrature node.
         pf = if SciMLBase.isinplace(sol.prob.f)
             if _needs_repack
-                let _f = unwrappedf, repack = repack
+                let _f = enzyme_rhs(unwrappedf), repack = repack
                     SciMLBase.Void((du, u, tunables, t) -> _f(du, u, repack(tunables), t))
                 end
             else
-                SciMLBase.Void(unwrappedf)
+                SciMLBase.Void(enzyme_rhs(unwrappedf))
             end
         else
             unwrappedf

--- a/src/gauss_adjoint.jl
+++ b/src/gauss_adjoint.jl
@@ -645,10 +645,17 @@ function vec_pjac!(out, λ, y, t, S::GaussIntegrand)
             vtmp4 .= λ
             Enzyme.remake_zero!(tmp3)
             Enzyme.remake_zero!(out)
-            Enzyme.remake_zero!(tmp6)
+            # same fast path as `_vecjacobian!`: no differentiable state in `pf`
+            # (`make_zero` returned the primal) ⇒ `Const`, no shadow to re-zero
+            fdup = if tmp6 === pf || Base.issingletontype(typeof(pf))
+                Enzyme.Const(pf)
+            else
+                Enzyme.remake_zero!(tmp6)
+                Enzyme.Duplicated(pf, tmp6)
+            end
 
             Enzyme.autodiff(
-                sensealg.autojacvec.mode, Enzyme.Duplicated(pf, tmp6), Enzyme.Const,
+                sensealg.autojacvec.mode, fdup, Enzyme.Const,
                 Enzyme.Duplicated(tmp3, tmp4),
                 Enzyme.Const(y), Enzyme.Duplicated(tunables, out), Enzyme.Const(t)
             )

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -303,7 +303,9 @@ function AdjointSensitivityIntegrand(sol, adj_sol, sensealg, dgdp = nothing)
         pf = nothing
         pJ = nothing
     elseif sensealg.autojacvec isa EnzymeVJP
-        pf = SciMLBase.isinplace(sol.prob.f) ? SciMLBase.Void(unwrappedf) : unwrappedf
+        # bare rhs, see `enzyme_rhs`; must match the primal in `vec_pjac!`
+        pf = SciMLBase.isinplace(sol.prob.f) ? SciMLBase.Void(enzyme_rhs(unwrappedf)) :
+             unwrappedf
         paramjac_config = zero(y), zero(y), Enzyme.make_zero(pf)
         pJ = nothing
     elseif sensealg.autojacvec isa MooncakeVJP
@@ -471,10 +473,18 @@ function vec_pjac!(out, λ, y, t, S::AdjointSensitivityIntegrand)
             end
 
             if SciMLBase.isinplace(sol.prob.f)
-                Enzyme.remake_zero!(tmp6)
+                vf = SciMLBase.Void(enzyme_rhs(f))
+                # no differentiable state in the rhs ⇒ `make_zero` returned the
+                # primal itself: pass it `Const`, no shadow to re-zero
+                fdup = if tmp6 === vf || Base.issingletontype(typeof(vf))
+                    Enzyme.Const(vf)
+                else
+                    Enzyme.remake_zero!(tmp6)
+                    Enzyme.Duplicated(vf, tmp6)
+                end
                 Enzyme.autodiff(
                     sensealg.autojacvec.mode,
-                    Enzyme.Duplicated(SciMLBase.Void(f), tmp6), Enzyme.Const,
+                    fdup, Enzyme.Const,
                     Enzyme.Duplicated(tmp3, tmp4),
                     Enzyme.Const(y), dup, Enzyme.Const(t)
                 )

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -305,7 +305,7 @@ function AdjointSensitivityIntegrand(sol, adj_sol, sensealg, dgdp = nothing)
     elseif sensealg.autojacvec isa EnzymeVJP
         # bare rhs, see `enzyme_rhs`; must match the primal in `vec_pjac!`
         pf = SciMLBase.isinplace(sol.prob.f) ? SciMLBase.Void(enzyme_rhs(unwrappedf)) :
-             unwrappedf
+             enzyme_rhs(unwrappedf)
         paramjac_config = zero(y), zero(y), Enzyme.make_zero(pf)
         pJ = nothing
     elseif sensealg.autojacvec isa MooncakeVJP
@@ -489,10 +489,25 @@ function vec_pjac!(out, λ, y, t, S::AdjointSensitivityIntegrand)
                     Enzyme.Const(y), dup, Enzyme.Const(t)
                 )
             else
-                tmp6 = Enzyme.make_zero(f)
+                # out-of-place: same shadow handling as `_vecjacobian!` — reuse the
+                # cached shadow when it was built for this rhs, `Const` when the
+                # rhs carries no differentiable state (Enzyme rejects `Duplicated`
+                # for ghost types)
+                rhs = enzyme_rhs(f)
+                shadow = if tmp6 !== rhs && typeof(tmp6) === typeof(rhs)
+                    Enzyme.remake_zero!(tmp6)
+                    tmp6
+                else
+                    Enzyme.make_zero(rhs)
+                end
+                fdup = if shadow === rhs || Base.issingletontype(typeof(rhs))
+                    Enzyme.Const(rhs)
+                else
+                    Enzyme.Duplicated(rhs, shadow)
+                end
                 Enzyme.autodiff(
                     sensealg.autojacvec.mode, Enzyme.Const(gclosure4), Enzyme.Const,
-                    Enzyme.Duplicated(f, tmp6),
+                    fdup,
                     Enzyme.Duplicated(tmp3, tmp4),
                     Enzyme.Const(y), dup, Enzyme.Const(t)
                 )

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -305,7 +305,7 @@ function AdjointSensitivityIntegrand(sol, adj_sol, sensealg, dgdp = nothing)
     elseif sensealg.autojacvec isa EnzymeVJP
         # bare rhs, see `enzyme_rhs`; must match the primal in `vec_pjac!`
         pf = SciMLBase.isinplace(sol.prob.f) ? SciMLBase.Void(enzyme_rhs(unwrappedf)) :
-             enzyme_rhs(unwrappedf)
+            enzyme_rhs(unwrappedf)
         paramjac_config = zero(y), zero(y), Enzyme.make_zero(pf)
         pJ = nothing
     elseif sensealg.autojacvec isa MooncakeVJP

--- a/test/Core8/mtk.jl
+++ b/test/Core8/mtk.jl
@@ -8,6 +8,7 @@ using SciMLSensitivity
 using Enzyme
 using Mooncake
 using Tracker
+using Zygote
 import SciMLStructures as SS
 using SymbolicIndexingInterface
 using Test
@@ -279,4 +280,39 @@ let
     )
     @test sensealg_mtk isa GaussAdjoint
     @test !(sensealg_mtk.autojacvec isa Bool)
+end
+
+@testset "EnzymeVJP differentiates the bare rhs, not the ODEFunction container" begin
+    # The `ODEFunction` container drags `sys`, `observed` and `initialization_data`
+    # into Enzyme's shadow, which then has to be re-zeroed on every VJP call
+    # (~190 µs per call for a 32-state MTK system). The VJP only calls the rhs.
+    @parameters k = 2.0
+    @variables x(t) = 1.0
+    @named sys = System([D(x) ~ -k * x], t)
+    sys = mtkcompile(sys)
+    prob = ODEProblem(sys, [], (0.0, 1.0))
+    rhs = SciMLSensitivity.enzyme_rhs(prob.f)
+    @test rhs === prob.f.f
+    # no differentiable state left: Enzyme needs no shadow, so `_vecjacobian!`
+    # passes the function `Const` instead of `Duplicated`
+    vf = SciMLBase.Void(rhs)
+    @test Enzyme.make_zero(vf) === vf
+    # and the peeled function must still be the same rhs
+    du = zero(prob.u0)
+    rhs(du, prob.u0, prob.p, 0.0)
+    du_ref = zero(prob.u0)
+    prob.f(du_ref, prob.u0, prob.p, 0.0)
+    @test du == du_ref
+
+    tunables, repack, _ = SS.canonicalize(SS.Tunable(), prob.p)
+    g = Zygote.gradient(tunables) do tunables
+        sum(solve(prob, Tsit5(); p = repack(tunables), saveat = 0.1,
+            abstol = 1e-8, reltol = 1e-8,
+            sensealg = GaussAdjoint(; autojacvec = SciMLSensitivity.EnzymeVJP())))
+    end[1]
+    g_fwd = Zygote.gradient(tunables) do tunables
+        sum(solve(prob, Tsit5(); p = repack(tunables), saveat = 0.1,
+            abstol = 1e-8, reltol = 1e-8, sensealg = ForwardDiffSensitivity()))
+    end[1]
+    @test g ≈ g_fwd rtol = 1e-5
 end

--- a/test/Core8/mtk.jl
+++ b/test/Core8/mtk.jl
@@ -306,13 +306,21 @@ end
 
     tunables, repack, _ = SS.canonicalize(SS.Tunable(), prob.p)
     g = Zygote.gradient(tunables) do tunables
-        sum(solve(prob, Tsit5(); p = repack(tunables), saveat = 0.1,
-            abstol = 1e-8, reltol = 1e-8,
-            sensealg = GaussAdjoint(; autojacvec = SciMLSensitivity.EnzymeVJP())))
+        sum(
+            solve(
+                prob, Tsit5(); p = repack(tunables), saveat = 0.1,
+                abstol = 1.0e-8, reltol = 1.0e-8,
+                sensealg = GaussAdjoint(; autojacvec = SciMLSensitivity.EnzymeVJP())
+            )
+        )
     end[1]
     g_fwd = Zygote.gradient(tunables) do tunables
-        sum(solve(prob, Tsit5(); p = repack(tunables), saveat = 0.1,
-            abstol = 1e-8, reltol = 1e-8, sensealg = ForwardDiffSensitivity()))
+        sum(
+            solve(
+                prob, Tsit5(); p = repack(tunables), saveat = 0.1,
+                abstol = 1.0e-8, reltol = 1.0e-8, sensealg = ForwardDiffSensitivity()
+            )
+        )
     end[1]
-    @test g ≈ g_fwd rtol = 1e-5
+    @test g ≈ g_fwd rtol = 1.0e-5
 end


### PR DESCRIPTION
## What

- `enzyme_rhs(f)`: the function the Enzyme VJPs differentiate; identity except for
  `ODEFunction`, where it is `unwrapped_f(f.f)`. Used wherever an EnzymeVJP shadow is
  built and consumed: `adjointdiffcache` + `_vecjacobian!(::EnzymeVJP)`, and the
  `GaussIntegrand`/`AdjointSensitivityIntegrand` `vec_pjac!` paths, which had their own
  copy of the container shadow (Gauss captures it in the `repack` closure).
  `DAEFunction`s already get exactly this via `dae_unwrapped_f`.
- In `_vecjacobian!(::EnzymeVJP)`, pass the function `Const` and skip `remake_zero!`
  when `make_zero` handed back the primal itself (no differentiable state) or the
  type is a singleton; the DAE variant already does the singleton half of this.
- `enzyme_rhs` keeps an `ODEFunction` whole when `f.f` is an `AbstractSciMLOperator`
  (the container's call forwards `f.f(du, u, u, p, t)`, which the bare operator would
  not), and unwraps in the fallback so the call site no longer rebuilds the container
  per VJP. Its docstring states the two-sided contract (shadow at config time, primal at
  call time, both through `enzyme_rhs`).
- Out-of-place `EnzymeVJP` paths now handle a peeled rhs that is a ghost type (Enzyme
  rejects `Duplicated` for those): they reuse the cached shadow when it was built for
  this rhs and pass `Const` when the rhs has no differentiable state, like the in-place
  paths; this also drops a pre-existing per-call `make_zero`.
- Test in `test/Core8/mtk.jl`.

Test groups run locally on the final branch: Core6 (238 pass / 4 pre-existing broken),
Core8 (96 pass / 5 pre-existing broken).

## Why

`EnzymeVJP` was re-zeroing a shadow of the entire `ODEFunction` on every adjoint rhs
evaluation. Measured on a chain of 32 linear ODEs (`D(x_i) = -k_i x_i + x_{i-1}`, 51 save
points, Tsit5, abstol = reltol = 1e-8, Julia 1.12.7, SciMLSensitivity master `6fcf58d1`,
Enzyme main `c5f5b55d`, ModelingToolkit v11.42.0):

| piece | time |
|---|---|
| plain rhs call | 5 ns |
| `remake_zero!` of the `Void(f)` shadow | 188 µs |
| of which `f.initialization_data.metadata` | 97 µs |
| one `EnzymeVJP` call | 187 µs |

| `GaussAdjoint(EnzymeVJP)` gradient, N = 32 | full problem | `initialization_data` stripped |
|---|---|---|
| before | 255 ms | 13.3 ms |
| SciML/ModelingToolkit.jl#5094 alone (`InitializationMetadata` inactive) | 60 ms | — |
| this PR alone | 103 ms | — |
| this PR together with #5094 | 21 ms | 1.4 ms |
| `GaussAdjoint(ReverseDiffVJP(true))`, for reference | 19 ms | 3.9 ms |

The "stripped" column removes the initialization problem from `f` so only the adjoint is
measured; on the full problem the remaining ~17 ms is the initialization gradient, which is
the same for every VJP (`ReverseDiffVJP(true)` pays it too) and is not touched here.
With that out of the way `EnzymeVJP` is now the fastest VJP in every adjoint family
(Interpolating 1.06 vs 2.74 ms, Quadrature 2.3 vs 5.4 ms against compiled ReverseDiff).

Gradients agree to 1.7e-10 with forward sensitivities throughout.

Not addressed here: the initialization gradient. On the full problem ~17 ms per gradient
remain in `_init_originator_gradient` (Zygote pullback through `get_initial_values`) plus
the eager init re-solve inside `remake`, independent of the VJP choice.

This matters beyond MTK users who pin `EnzymeVJP`: `automatic_sensealg_choice` picks
`GaussAdjoint(autojacvec = EnzymeVJP())` for in-place ODEs once
`length(u0) + length(tunables) > 100`, so the default adjoint path paid this on every
ModelingToolkit problem.

Complementary to SciML/ModelingToolkit.jl#5094, which marks `InitializationMetadata`
inactive so that any other `Duplicated` use of an MTK `ODEFunction` benefits too; this
PR removes the VJP's dependence on how the container is structured at all. The two
remove different shadows: with this PR alone a per-gradient `InitializationMetadata`
shadow remains outside the VJP (most likely in the initialization adjoint, which
differentiates through the init problem), which is what #5094 covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code) on Sebastian's behalf.
