### PR TITLE
Remake lazily inside `init_loss` so the init gradient is taken once

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -740,7 +740,7 @@ function SciMLBase._concrete_solve_adjoint(
                     initializealg = initializealg, nlsolve_alg = nlsolve_alg,
                     sensealg = sensealg, kwargs_init = kwargs_init
                 function (t)
-                    new_prob_t = remake(_prob, p = repack(t))
+                    new_prob_t = remake(_prob, p = repack(t), lazy_initialization = true)
                     nu0, _,
                         _ = SciMLBase.get_initial_values(
                         new_prob_t, new_prob_t, new_prob_t.f, initializealg,


### PR DESCRIPTION
Follow-up to #1642 (now merged); rebased onto master, single commit.

The `init_loss` closure handed to `_init_originator_gradient` does two things: `remake(_prob, p = repack(t))` and then an explicit `get_initial_values(new_prob_t, ...)`, whose result is what the closure returns. When the problem's initialization is trivial, `remake` defaults to `lazy_initialization = false` and runs the initialization eagerly as well, so the AD backend builds a pullback through the same initialization twice per gradient. The explicit call is the one we want; the remake only needs to swap `p`.

Passing `lazy_initialization = true` to that remake removes the redundant differentiated initialization. Non-trivial initializations are already lazy by default, so nothing changes for them.

Checked locally (MTK `System([D(x) ~ -k*x], initialization_eqs = [x ~ a])`, Rodas5P, saveat 0.1): `GaussAdjoint(EnzymeVJP)` and `InterpolatingAdjoint(ReverseDiffVJP(true))` gradients are bit-identical before and after; the Gauss gradient time went 9.8 → 7.8 ms (indicative only, measured on a loaded machine). Note that the `d/da` component is wrong (`1.0`) both before and after, which is the known `sum(nu0)` seeding of `igs` and is not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015FGPhFNRbVzAki3xsf6DFP
