### PR TITLE
Require Symbolics 7.39.2 for 32-bit hash CI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -139,7 +139,7 @@ SymbolicIndexingInterface = "0.3.48"
 Test = "1.10"
 Tracker = "0.2.38"
 Zygote = "0.7.11"
-Symbolics = "7.37"
+Symbolics = "7.39.2"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
## Summary
- Require `Symbolics ≥ 7.39.2` (Differential hash `% UInt` + SymbolicUtils 4.46.4 hasha_seed).
- Default-branch x86 was failing on 32-bit hash/`UInt64` dispatch.

## Test plan
- [ ] x86 lane green (or fails for an unrelated reason)
- [ ] x64 unchanged
