### PR TITLE
Release SciMLSensitivity 7.119.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLSensitivity"
 uuid = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
-version = "7.119.3"
+version = "7.119.4"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Bumps `SciMLSensitivity` 7.119.3 -> 7.119.4 (patch).

Source files changed since 7.119.3:
- `src/SciMLSensitivity.jl`
- `src/adjoint_common.jl`
- `src/derivative_wrappers.jl`
- `src/gauss_adjoint.jl`
- `src/quadrature_adjoint.jl`

Commits:
- Add 32-bit Core1 CI lane via test_groups.toml (#1639)
- Differentiate the bare rhs in `EnzymeVJP`, not the `ODEFunction` container (#1642)
- Drop Zygote from SDE control example and adjoint benchmarks. (#1645)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
