### PR TITLE
Fix Quadrature/Gauss ReverseDiffVJP for t-branching RHS (e.g. solution interpolant)

### DIFF
--- a/src/gauss_adjoint.jl
+++ b/src/gauss_adjoint.jl
@@ -605,7 +605,23 @@ function vec_pjac!(out, λ, y, t, S::GaussIntegrand)
         # Use pJ' * λ instead of out' = λ' * pJ to avoid GPU scalar indexing
         mul!(vec(out), pJ', λ)
     elseif sensealg.autojacvec isa ReverseDiffVJP
-        tape = paramjac_config
+        # Re-trace for `compile=false` (see quadrature_adjoint.jl).
+        tape = if compile_tape(sensealg.autojacvec)
+            paramjac_config
+        else
+            if DiffEqBase.isinplace(sol.prob)
+                ReverseDiff.GradientTape((y, tunables, [t])) do u_, p_, t_
+                    du1 = similar(p_, size(u_))
+                    du1 .= false
+                    f(du1, u_, repack(p_), first(t_))
+                    return vec(du1)
+                end
+            else
+                ReverseDiff.GradientTape((y, tunables, [t])) do u_, p_, t_
+                    vec(f(u_, repack(p_), first(t_)))
+                end
+            end
+        end
         tu, tp, tt = ReverseDiff.input_hook(tape)
         output = ReverseDiff.output_hook(tape)
         ReverseDiff.unseed!(tu) # clear any "leftover" derivatives from previous calls

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -395,7 +395,24 @@ function vec_pjac!(out, λ, y, t, S::AdjointSensitivityIntegrand)
         # Use pJ' * λ instead of out' = λ' * pJ to avoid GPU scalar indexing
         mul!(vec(out), pJ', λ)
     elseif sensealg.autojacvec isa ReverseDiffVJP
-        tape = paramjac_config
+        # Re-trace for `compile=false`: a cached tape freezes `t`-branching
+        # (e.g. RHS closing over a solution interpolant).
+        tape = if compile_tape(sensealg.autojacvec)
+            paramjac_config
+        else
+            if DiffEqBase.isinplace(sol.prob)
+                ReverseDiff.GradientTape((y, tunables, [t])) do u_, p_, t_
+                    du1 = similar(p_, size(u_))
+                    du1 .= false
+                    f(du1, u_, repack(p_), first(t_))
+                    return vec(du1)
+                end
+            else
+                ReverseDiff.GradientTape((y, tunables, [t])) do u_, p_, t_
+                    vec(f(u_, repack(p_), first(t_)))
+                end
+            end
+        end
         tu, tp, tt = ReverseDiff.input_hook(tape)
         output = ReverseDiff.output_hook(tape)
         ReverseDiff.unseed!(tu) # clear any "leftover" derivatives from previous calls

--- a/test/Core3/reversediff_interpolant_forcing.jl
+++ b/test/Core3/reversediff_interpolant_forcing.jl
@@ -1,0 +1,56 @@
+using SciMLSensitivity, OrdinaryDiffEq, LinearAlgebra, Test
+
+# Regression test for https://github.com/SciML/SciMLSensitivity.jl/issues/1649
+# RHS parameter dependence comes from the dense interpolant of another
+# ODESolution, `ref(t)`. A cached ReverseDiff tape traced once at `tspan[2]`
+# freezes `t`-dependent control flow inside the interpolant, giving a ~5% wrong
+# `df/dp` in QuadratureAdjoint/GaussAdjoint. InterpolatingAdjoint re-traces its
+# tape per evaluation and was already correct.
+@testset "ReverseDiffVJP with solution-interpolant forcing (#1649)" begin
+    A = [-0.3 1.0; -1.0 -0.3]
+    u0 = [1.0, 0.5]
+    tspan = (0.0, 3.0)
+    v = [1.0, 0.0]
+
+    base!(du, u, p, t) = (mul!(du, A, u); nothing)
+    ref = solve(
+        ODEProblem(base!, u0, tspan), Tsit5();
+        abstol = 1e-10, reltol = 1e-10, dense = true, save_everystep = true
+    )
+
+    function forced!(du, u, eps, t)
+        mul!(du, A, u)
+        r = ref(t)
+        du[1] += eps[1] * r[1]
+        du[2] += eps[1] * r[2]
+        return nothing
+    end
+
+    Gof(e) = begin
+        s = solve(
+            ODEProblem(forced!, u0, tspan, [e]), Tsit5();
+            abstol = 1e-11, reltol = 1e-11
+        )
+        dot(v, s.u[end])
+    end
+    fd = (Gof(1e-6) - Gof(-1e-6)) / 2e-6
+
+    sol = solve(
+        ODEProblem(forced!, u0, tspan, [0.0]), Tsit5();
+        abstol = 1e-10, reltol = 1e-10, dense = true, save_everystep = true
+    )
+    dgdu = (out, u, p, t, i) -> (copyto!(out, v); nothing)
+
+    for (name, sa) in [
+            ("InterpolatingAdjoint", InterpolatingAdjoint(autojacvec = ReverseDiffVJP())),
+            ("QuadratureAdjoint", QuadratureAdjoint(autojacvec = ReverseDiffVJP())),
+            ("GaussAdjoint", GaussAdjoint(autojacvec = ReverseDiffVJP())),
+            ("QuadratureAdjoint(false)", QuadratureAdjoint(autojacvec = false)),
+        ]
+        _, dp = adjoint_sensitivities(
+            sol, Tsit5(); sensealg = sa, t = [tspan[2]],
+            dgdu_discrete = dgdu, abstol = 1e-10, reltol = 1e-10
+        )
+        @test only(dp) ≈ fd rtol = 1e-5
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,7 @@ run_tests(;
                 @time @safetestset "Adjoint Allocation Regression" include("Core3/allocation_regression.jl")
                 @time @safetestset "SensitivityFunction developer interface" include("Core3/sensitivity_interface.jl")
                 @time @safetestset "User-provided VJP" include("Core3/user_vjp.jl")
+                @time @safetestset "ReverseDiff interpolant forcing" include("Core3/reversediff_interpolant_forcing.jl")
             end
         end,
         "Core4" => function ()


### PR DESCRIPTION
Fixes #1649.

QuadratureAdjoint/GaussAdjoint with `ReverseDiffVJP()` returned a ~5% wrong parameter gradient when the RHS closes over a solution interpolant `ref(t)`. The integrand reused a single `ReverseDiff.GradientTape` traced at `tspan[2]`, which freezes `t`-dependent control flow. Now it re-traces per evaluation when `compile=false` (mirroring `_vecjacobian!`, which is why `InterpolatingAdjoint` was already correct). `compile=true` still reuses the cached tape (documented branch-free only).

Verification (run locally, see below for full outputs):

MWE from #1649, before:

FD dG/deps = -1.1214400671422098
InterpolatingAdjoint dp=-1.1214400669567082 dp/FD=0.99999999983
QuadratureAdjoint dp=-1.0650523169522677 dp/FD=0.94971844520
GaussAdjoint dp=-1.0650523170651716 dp/FD=0.94971844530

MWE after fix:

FD dG/deps = -1.1214400671422098
InterpolatingAdjoint dp=-1.1214400669567082
QuadratureAdjoint dp=-1.121440066954683
GaussAdjoint dp=-1.1214400669554305

New regression test `test/Core3/reversediff_interpolant_forcing.jl`:

Without fix (registry v7.119.4, no dev): 2 passed, 2 failed
`Evaluated: -1.0650523170651716 ≈ -1.1214400671422098 (rtol=1.0e-5)`

With fix (this branch, dev): 4 passed, 0 failed
`Test Summary: | Pass Total Time | 4 4 1m02.6s`

Also checked: oop + inplace variants agree, structured `ComponentArray` params agree, non-branching linear problem `I/Q/G/Qc` agree, `t<1.5` branching `Interp`/`Quad` agree and converge to FD at tight tol.

Not verified:

Full Core3/Core1 suite and QA group not run locally (time); left for CI. GPU/downstream not run. EnzymeVJP `LLVM ERROR` noted in #1649 is separate (Enzyme differentiating through interpolant) and not addressed here.

Reviewer notes:

Retracing per quadrature node costs more than reusing, but matches existing `InterpolatingAdjoint(ReverseDiffVJP(false))` cost model. Alternative would be a shared helper for both integrands; kept minimal to mirror existing duplicated `vec_pjac!` structure.

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [OpenCode](https://github.com/anomalyco/opencode) (model: opencode/muse-spark-1.3-contributor-free)
Session: /home/crackauc/sandbox/tmp_20260911_055415_17778 (local, no shareable URL)
