### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "OrdinaryDiffEq,ForwardDiff,ADTypes"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,58 @@
+using SciMLSensitivity, OrdinaryDiffEq, ForwardDiff, ADTypes, BenchmarkTools
+
+const SUITE = BenchmarkGroup()
+
+# Lotka-Volterra
+function lotka!(du, u, p, t)
+    du[1] = p[1] * u[1] - u[1] * u[2]
+    du[2] = -p[2] * u[2] + u[1] * u[2]
+    return nothing
+end
+u0 = [1.0, 1.0]
+p = [1.5, 1.0]
+tspan = (0.0, 10.0)
+prob = ODEProblem(lotka!, u0, tspan, p)
+
+# =============================================================================
+# Forward sensitivity
+# =============================================================================
+
+SUITE["forward"] = BenchmarkGroup()
+
+fs_prob = ODEForwardSensitivityProblem(ODEFunction(lotka!), u0, tspan, p)
+SUITE["forward"]["solve"] = @benchmarkable solve($fs_prob, Tsit5())
+SUITE["forward"]["construct"] = @benchmarkable ODEForwardSensitivityProblem(
+    $(ODEFunction(lotka!)), $u0, $tspan, $p
+)
+
+# =============================================================================
+# Parameter gradient via ForwardDiff through the solver
+# =============================================================================
+
+SUITE["gradient"] = BenchmarkGroup()
+
+function loss(pvec)
+    _prob = remake(prob; p = pvec)
+    return sum(Array(solve(_prob, Tsit5(); saveat = 0.1)))
+end
+
+SUITE["gradient"]["forwarddiff"] = @benchmarkable ForwardDiff.gradient($loss, $p)
+SUITE["gradient"]["loss_eval"] = @benchmarkable $loss($p)
+
+# =============================================================================
+# Adjoint sensitivity solve
+# =============================================================================
+
+SUITE["adjoint"] = BenchmarkGroup()
+
+sol = solve(prob, Tsit5(); saveat = 0.1)
+dg(out, u, p, t, i) = (out .= 1.0)
+
+SUITE["adjoint"]["interpolating"] = @benchmarkable adjoint_sensitivities(
+    $sol, Tsit5(); t = $(sol.t), dgdu_discrete = $dg,
+    sensealg = InterpolatingAdjoint(autodiff = AutoFiniteDiff(), autojacvec = false)
+)
+SUITE["adjoint"]["quadrature"] = @benchmarkable adjoint_sensitivities(
+    $sol, Tsit5(); t = $(sol.t), dgdu_discrete = $dg,
+    sensealg = QuadratureAdjoint(autodiff = AutoForwardDiff(), autojacvec = false)
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~78s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~78s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md