### PR TITLE
Fix checkpointed InterpolatingAdjoint double-applying callback affect

### DIFF
--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -445,8 +445,16 @@ function _setup_reverse_callbacks(
         # if save_positions[2] = false, then the right limit is not saved. Thus, for
         # the QuadratureAdjoint we would need to lift y from the left to the right limit.
         # However, one also needs to update dgrad later on.
-        if (sensealg isa QuadratureAdjoint && !cb.save_positions[2]) ||
-                (sensealg isa InterpolatingAdjoint && ischeckpointing(sensealg))
+        if sensealg isa QuadratureAdjoint && !cb.save_positions[2]
+            w(y, y, integrator.p, integrator.t)
+        elseif sensealg isa InterpolatingAdjoint && ischeckpointing(sensealg)
+            # The checkpoint re-solve can locate the event a floating-point ulp
+            # away from the tracked event time, so `y` (from
+            # `cpsol(t, continuity = :right)`) may hold either limit. Rebuild the
+            # right limit from the recorded left limit so the event correction
+            # uses a consistent state either way.
+            _uleft = pos_neg ? cb.affect!.uleft[indx] : cb.affect_neg!.uleft[indx]
+            copyto!(y, _uleft)
             w(y, y, integrator.p, integrator.t)
         end
 


### PR DESCRIPTION
## Summary

In the reverse-pass event correction (`_setup_reverse_callbacks`), `w(y, y, p, t)` lifts `y` from the left limit to the right limit of an event so `dy_right = f(y)` and the implicit event-time correction see the post-event state.

For `InterpolatingAdjoint(checkpointing = true)`, `y` at the event time comes from `checkpoint_sol.cpsol(y, t, continuity = :right)`. Whether that call returns the right limit depends on the checkpoint re-solve having located the event at exactly the tracked event time — which is FP-sensitive:

- On Julia 1.12/1.13 the re-solve's event coincides with the tracked time → `y` is already the right limit → the unconditional `w` **double-applied** the affect (in the `+=` test, `u[2] += 50` became `+= 100`), corrupting `dy_right`.
- On Julia 1.11 (and presumably 1.10) the re-solve's event lands one ulp later than the tracked time → `y` is still the left limit → the `w` lift is **required**.

So neither applying nor skipping the lift is correct on all versions. Instead, this PR rebuilds the right limit deterministically: reset `y` to the recorded left limit `affect.uleft[indx]` (the same source `copy_to_integrator!` uses a few lines below) and then apply `w`. The event correction is now identical regardless of where the re-solve's event landed.

Concretely, for the `+=` callback test:

- `BacksolveAdjoint`: `du = [-11.1322, -1.8061]`, `dp = [-7.6544, 0]`
- `InterpolatingAdjoint(checkpointing=true)` on master, Julia 1.13: `du = [-26.2845, -17.1122]` (double-applied)
- with the first version of this PR, Julia 1.11: `du = [4.0201, 13.5]` (lift wrongly skipped)
- with this PR: `du = [-11.1322, -1.8061]` on Julia 1.11, 1.12, and 1.13 — matching `BacksolveAdjoint` and non-checkpointed `InterpolatingAdjoint`

The QuadratureAdjoint lift under `save_positions[2] == false` is unchanged.

Failing CI this addresses: `Callbacks2 (julia 1)` on master, e.g. run [34590667340](https://github.com/SciML/SciMLSensitivity.jl/actions/runs/34590667340). (The first push of this branch regressed `Callbacks2 (julia 1.11/lts)` — now fixed by the reset-to-left-limit approach.)

## Test plan

- [x] `test/Callbacks2/continuous_callbacks.jl`: 165/165 pass on Julia 1.12
- [x] checkpointed-vs-backsolve gradient comparison matches on Julia 1.11.9, 1.12.4, and 1.13.0
- [x] `test/Callbacks2/continuous_vs_discrete.jl`: 36/36 pass
- [x] `test/Callbacks2/vector_continuous_callbacks.jl`: 11/11 pass

🤖 Generated with [Devin](https://devin.ai) (harness: Devin CLI 3000.10.21, model: SWE-2 Max)
Session transcript (local, no shareable URL): /home/crackauc/.local/share/devin/cli/summaries/history_3465c349dc8b452b.md
