### PR TITLE
Preserve structured tunables type when resetting callback integrand

### DIFF
--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -786,7 +786,7 @@ function _update_integrand_and_dgrad(
 
     # `wp` writes the tunable portion of the post-event parameters; the integrand
     # is rebuilt from the full parameter object, so repack before comparing.
-    _pt = similar(integrand.tunables, size(integrand.tunables))
+    _pt = similar(integrand.tunables)
     _pt .= false
     wp(_pt, integrand.y, integrand.p, t)
 


### PR DESCRIPTION
## Summary

`_update_integrand_and_dgrad` (used to rebuild the Quadrature/Gauss adjoint integrand after a callback) computed the new tunables via

```julia
_pt = similar(integrand.tunables, size(integrand.tunables))
```

For a `ComponentVector`, `similar(x, size(x))` drops the axes and returns a plain `Vector`, so the rebuilt integrand lost its structured-parameter axes. Since #1650, the ReverseDiff tape is retraced per integrand evaluation and replays `repack`/`getproperty` against the tunables — with a plain `Vector` this errors with

```
type TrackedArray has no field layer_1
```

`similar(tunables)` preserves the `ComponentVector` structure.

Failing CI this addresses: `Core5` on master after #1650, e.g. run [34588184142](https://github.com/SciML/SciMLSensitivity.jl/actions/runs/34588184142) (`HybridNODE` test failure, all Julia versions).

## Test plan

- [x] The `Core5` `HybridNODE` test set passes locally with this change (was erroring with `TrackedArray has no field layer_1`)
- [x] `test/SDE*/sde_scalar_stratonovich.jl`, `sde_nondiag_stratonovich.jl` and the 20 related SDE/QA test files pass on Julia 1.13

🤖 Generated with [Devin](https://devin.ai) (harness: Devin CLI, model: SWE-2 Max)
Session transcript (local, no shareable URL): /home/crackauc/.local/share/devin/cli/summaries/history_343a17b425e94c53.md