### PR TITLE
Despecialize AutoSpecialize FunctionWrappers in adjoint and forward sensitivity paths

### DIFF
--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -42,6 +42,62 @@ struct AdjointDiffCache{
     index2::Bool
 end
 
+# `promote_f` wraps `f`/`g` of `ODEFunction`/`SDEFunction` in fixed-signature
+# FunctionWrappers under AutoSpecialize; sensitivity evaluation calls them with
+# SubArray/Dual arguments that the wrapper rejects, so strip the wrapper here.
+function _despecialized_f(f::ODEFunction)
+    if f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper
+        return ODEFunction{isinplace(f), true}(unwrapped_f(f))
+    end
+    return f
+end
+function _despecialized_f(f::SDEFunction)
+    if f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper ||
+            f.g isa FunctionWrappersWrappers.FunctionWrappersWrapper
+        _uf = unwrapped_f(f)
+        return SDEFunction{isinplace(f), true}(
+            _uf.f, _uf.g;
+            mass_matrix = _uf.mass_matrix, analytic = _uf.analytic,
+            tgrad = _uf.tgrad, jac = _uf.jac, jvp = _uf.jvp, vjp = _uf.vjp,
+            jac_prototype = _uf.jac_prototype, sparsity = _uf.sparsity,
+            Wfact = _uf.Wfact, Wfact_t = _uf.Wfact_t,
+            paramjac = _uf.paramjac, ggprime = _uf.ggprime,
+            observed = _uf.observed, colorvec = _uf.colorvec,
+            sys = _uf.sys, initialization_data = _uf.initialization_data
+        )
+    end
+    return f
+end
+_despecialized_f(f) = f
+
+# Build a FullSpecialize copy of the (possibly FunctionWrapper-wrapped) `f` for
+# ForwardDiffSensitivity solves whose u0/p carry Dual numbers; the wrapped
+# function only supports the signature `promote_f` compiled it for.
+function _dual_f(f::ODEFunction, elT)
+    _uf = unwrapped_f(f)
+    if f.jac_prototype !== nothing
+        return ODEFunction{isinplace(f), SciMLBase.FullSpecialize}(
+            _uf; jac_prototype = convert.(elT, f.jac_prototype)
+        )
+    end
+    return ODEFunction{isinplace(f), SciMLBase.FullSpecialize}(_uf)
+end
+function _dual_f(f::SDEFunction, elT)
+    _uf = unwrapped_f(f)
+    jp = f.jac_prototype === nothing ? nothing : convert.(elT, f.jac_prototype)
+    return SDEFunction{isinplace(f), SciMLBase.FullSpecialize}(
+        _uf.f, _uf.g;
+        mass_matrix = _uf.mass_matrix, analytic = _uf.analytic,
+        tgrad = _uf.tgrad, jac = _uf.jac, jvp = _uf.jvp, vjp = _uf.vjp,
+        jac_prototype = jp, sparsity = _uf.sparsity,
+        Wfact = _uf.Wfact, Wfact_t = _uf.Wfact_t,
+        paramjac = _uf.paramjac, ggprime = _uf.ggprime,
+        observed = _uf.observed, colorvec = _uf.colorvec,
+        sys = _uf.sys, initialization_data = _uf.initialization_data
+    )
+end
+_dual_f(f, elT) = f
+
 """
     adjointdiffcache(g,sensealg,discrete,sol,dg,alg;quad=false)
 

--- a/src/backsolve_adjoint.jl
+++ b/src/backsolve_adjoint.jl
@@ -154,12 +154,7 @@ end
     end
 
     ## Force recompile mode until vjps are specialized to handle this!!!
-    f = if sol.prob.f isa ODEFunction &&
-            sol.prob.f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper
-        ODEFunction{isinplace(sol.prob), true}(unwrapped_f(sol.prob.f))
-    else
-        sol.prob.f
-    end
+    f = _despecialized_f(sol.prob.f)
 
     # check if solution was terminated, then use reduced time span
     terminated = false
@@ -329,11 +324,11 @@ end
         sense_drift = ODEBacksolveSensitivityFunction(
             g, sensealg, discrete, sol,
             dgdu_continuous, dgdp_continuous,
-            sol.prob.f, alg
+            _despecialized_f(sol.prob.f), alg
         )
     else
         transformed_function = StochasticTransformedFunction(
-            sol, sol.prob.f, sol.prob.g,
+            sol, _despecialized_f(sol.prob.f), unwrapped_f(sol.prob.g),
             corfunc_analytical
         )
         drift_function = ODEFunction{false, true}(transformed_function)
@@ -345,7 +340,7 @@ end
     end
 
     diffusion_function = ODEFunction{isinplace(sol.prob), true}(
-        sol.prob.g,
+        unwrapped_f(sol.prob.g),
         jac = diffusion_jac,
         paramjac = diffusion_paramjac
     )

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -1456,43 +1456,20 @@ function SciMLBase._concrete_solve_adjoint(
 
                     ## Force recompile mode because it won't handle the duals
                     ## Would require a manual tag to be applied
-                    if prob.f isa ODEFunction
-                        if prob.f.jac_prototype !== nothing
-                            _f = ODEFunction{
-                                SciMLBase.isinplace(prob.f),
-                                SciMLBase.FullSpecialize,
-                            }(
-                                unwrapped_f(prob.f),
-                                jac_prototype = convert.(
-                                    eltype(u0dual),
-                                    prob.f.jac_prototype
-                                )
-                            )
-                        else
-                            _f = ODEFunction{
-                                SciMLBase.isinplace(prob.f),
-                                SciMLBase.FullSpecialize,
-                            }(unwrapped_f(prob.f))
-                        end
-                    elseif prob.f isa SDEFunction && prob.f.jac_prototype !== nothing
-                        _f = SDEFunction{
-                            SciMLBase.isinplace(prob.f),
-                            SciMLBase.FullSpecialize,
-                        }(
-                            unwrapped_f(prob.f),
-                            jac_prototype = convert.(
-                                eltype(u0dual),
-                                prob.f.jac_prototype
-                            )
+                    _f = _dual_f(prob.f, eltype(u0dual))
+                    # use the callback from kwargs, not prob
+                    _prob = if prob isa SDEProblem
+                        remake(
+                            prob, f = _f, g = unwrapped_f(prob.g),
+                            u0 = u0dual, p = pdual,
+                            tspan = tspandual, callback = nothing
                         )
                     else
-                        _f = prob.f
+                        remake(
+                            prob, f = _f, u0 = u0dual, p = pdual,
+                            tspan = tspandual, callback = nothing
+                        )
                     end
-                    # use the callback from kwargs, not prob
-                    _prob = remake(
-                        prob, f = _f, u0 = u0dual, p = pdual,
-                        tspan = tspandual, callback = nothing
-                    )
 
                     if _prob isa SDEProblem
                         _prob.noise_rate_prototype !== nothing && (
@@ -1652,35 +1629,7 @@ function SciMLBase._concrete_solve_adjoint(
 
                 ## Force recompile mode because it won't handle the duals
                 ## Would require a manual tag to be applied
-                if prob.f isa ODEFunction
-                    if prob.f.jac_prototype !== nothing
-                        _f = ODEFunction{
-                            SciMLBase.isinplace(prob.f),
-                            SciMLBase.FullSpecialize,
-                        }(
-                            unwrapped_f(prob.f),
-                            jac_prototype = convert.(
-                                eltype(pdual),
-                                prob.f.jac_prototype
-                            )
-                        )
-                    else
-                        _f = ODEFunction{
-                            SciMLBase.isinplace(prob.f),
-                            SciMLBase.FullSpecialize,
-                        }(unwrapped_f(prob.f))
-                    end
-                elseif prob.f isa SDEFunction && prob.f.jac_prototype !== nothing
-                    _f = SDEFunction{SciMLBase.isinplace(prob.f), SciMLBase.FullSpecialize}(
-                        unwrapped_f(prob.f),
-                        jac_prototype = convert.(
-                            eltype(pdual),
-                            prob.f.jac_prototype
-                        )
-                    )
-                else
-                    _f = prob.f
-                end
+                _f = _dual_f(prob.f, eltype(pdual))
 
                 _p = if p isa SciMLBase.NullParameters
                     p
@@ -1710,14 +1659,14 @@ function SciMLBase._concrete_solve_adjoint(
                 end
 
                 if _prob isa SDEProblem
-                    _prob.noise_rate_prototype !== nothing && (
-                        _prob = remake(
-                            _prob,
-                            noise_rate_prototype = convert.(
-                                eltype(pdual),
-                                _prob.noise_rate_prototype
+                    _prob = remake(
+                        _prob;
+                        g = unwrapped_f(_prob.g),
+                        noise_rate_prototype = _prob.noise_rate_prototype === nothing ?
+                            nothing :
+                            convert.(
+                                eltype(pdual), _prob.noise_rate_prototype
                             )
-                        )
                     )
                 end
 

--- a/src/gauss_adjoint.jl
+++ b/src/gauss_adjoint.jl
@@ -315,12 +315,7 @@ end
     (; p, u0, tspan) = sol.prob
 
     ## Force recompile mode until vjps are specialized to handle this!!!
-    f = if sol.prob.f isa ODEFunction &&
-            sol.prob.f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper
-        ODEFunction{isinplace(sol.prob), true}(unwrapped_f(sol.prob.f))
-    else
-        sol.prob.f
-    end
+    f = _despecialized_f(sol.prob.f)
 
     terminated = false
     if hasfield(typeof(sol), :retcode)

--- a/src/interpolating_adjoint.jl
+++ b/src/interpolating_adjoint.jl
@@ -342,12 +342,7 @@ end
     end
 
     ## Force recompile mode until vjps are specialized to handle this!!!
-    f = if sol.prob.f isa ODEFunction &&
-            sol.prob.f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper
-        ODEFunction{isinplace(sol.prob), true}(unwrapped_f(sol.prob.f))
-    else
-        sol.prob.f
-    end
+    f = _despecialized_f(sol.prob.f)
 
     # check if solution was terminated, then use reduced time span
     terminated = false
@@ -531,14 +526,14 @@ end
     sense_drift = ODEInterpolatingAdjointSensitivityFunction(
         g, sensealg, discrete, sol,
         dgdu_continuous,
-        dgdp_continuous, sol.prob.f,
+        dgdp_continuous, _despecialized_f(sol.prob.f),
         alg, checkpoints,
         (; reltol, abstol);
         tspan
     )
 
     diffusion_function = ODEFunction{isinplace(sol.prob), true}(
-        sol.prob.g,
+        unwrapped_f(sol.prob.g),
         jac = diffusion_jac,
         paramjac = diffusion_paramjac
     )

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -22,12 +22,12 @@ function ODEQuadratureAdjointSensitivityFunction(
         isscimlstructure(p) && !(p isa AbstractArray)
     diffcache,
         y = adjointdiffcache(
-        g, sensealg, discrete, sol, dgdu, dgdp, sol.prob.f, alg;
+        g, sensealg, discrete, sol, dgdu, dgdp, _despecialized_f(sol.prob.f), alg;
         quad = true, use_full_p = _use_full_p
     )
     return ODEQuadratureAdjointSensitivityFunction(
         diffcache, sensealg, discrete,
-        y, sol, sol.prob.f
+        y, sol, _despecialized_f(sol.prob.f)
     )
 end
 
@@ -114,12 +114,7 @@ end
     (; p, u0, tspan) = sol.prob
 
     ## Force recompile mode until vjps are specialized to handle this!!!
-    f = if sol.prob.f isa ODEFunction &&
-            sol.prob.f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper
-        ODEFunction{isinplace(sol.prob), true}(unwrapped_f(sol.prob.f))
-    else
-        sol.prob.f
-    end
+    f = _despecialized_f(sol.prob.f)
 
     terminated = false
     if hasfield(typeof(sol), :retcode)


### PR DESCRIPTION
## Summary

DiffEqBase 7.21.0 (SciML/OrdinaryDiffEq.jl#4467) extended `promote_f`'s FunctionWrapper specialization to `SDEFunction`, so `prob.f`/`prob.g` now carry single-signature `FunctionWrappersWrapper`s compiled for `Vector{Float64}` arguments. The adjoint VJPs invoke them with `SubArray`/`ForwardDiff.Dual` arguments, which the `AllowNonIsBits` policy rejects:

```
No matching function wrapper was found!
```

This broke SDE1, SDE2, and Callbacks1 on master (e.g. run [34468314723](https://github.com/SciML/SciMLSensitivity.jl/actions/runs/34468314723)); the ODE versions of these paths were already unwrapped (`backsolve_adjoint.jl`) but the SDE equivalents were not.

Changes:

- New `_despecialized_f` helper in `adjoint_common.jl`: rebuilds a `FullSpecialize` `ODEFunction`/`SDEFunction` via `unwrapped_f` whenever the inner `f`/`g` is a `FunctionWrappersWrapper`. Applied at every site that builds the adjoint sensitivity function from `sol.prob.f`/`sol.prob.g` (backsolve, interpolating, quadrature, gauss, concrete_solve).
- New `_dual_f` helper factoring the ForwardDiffSensitivity dual-solve rebuild; the SDE branch now also runs for problems without `jac_prototype`, and the `remake` additionally replaces the wrapped `prob.g` and converts `noise_rate_prototype` to the dual eltype (previously the SDE `remake` kept the wrapped `g`, and the single-argument `SDEFunction{iip, FullSpecialize}(f)` call used there does not exist).

## Test plan

- [x] `test/SDE*/sde_scalar_stratonovich.jl`: all pass (was `No matching function wrapper`)
- [x] `test/SDE*/sde_nondiag_stratonovich.jl`: 26/26 pass, including `ForwardDiffSensitivity` dual solves
- [x] `test/Callbacks1/` SDE callback test passes
- [x] Reproduced on Julia 1.12 with DiffEqBase 7.21.0 (the same versions CI used); fixes verified

🤖 Generated with [Devin](https://devin.ai) (harness: Devin CLI, model: SWE-2 Max)
Session transcript (local, no shareable URL): /home/crackauc/.local/share/devin/cli/summaries/history_343a17b425e94c53.md