### PR TITLE
Import Base-owned names from Base; Runic-format test file

### DIFF
--- a/src/SciMLSensitivity.jl
+++ b/src/SciMLSensitivity.jl
@@ -60,9 +60,10 @@ using Zygote: Zygote
 using ConstructionBase: ConstructionBase, setproperties
 
 # Std Libs
-using LinearAlgebra: LinearAlgebra, Diagonal, I, UniformScaling, adjoint, axpy!,
-    convert, copyto!, dot, issuccess, ldiv!, lmul!, lu, lu!, mul!,
-    norm, normalize!, qr, transpose, transpose!
+using Base: adjoint, copyto!, transpose
+using LinearAlgebra: LinearAlgebra, Diagonal, I, UniformScaling, axpy!,
+    convert, dot, issuccess, ldiv!, lmul!, lu, lu!, mul!,
+    norm, normalize!, qr, transpose!
 using Markdown: Markdown, @doc_str
 using Random: Random, rand!
 using SparseArrays: SparseArrays

--- a/test/Core3/reversediff_interpolant_forcing.jl
+++ b/test/Core3/reversediff_interpolant_forcing.jl
@@ -15,7 +15,7 @@ using SciMLSensitivity, OrdinaryDiffEq, LinearAlgebra, Test
     base!(du, u, p, t) = (mul!(du, A, u); nothing)
     ref = solve(
         ODEProblem(base!, u0, tspan), Tsit5();
-        abstol = 1e-10, reltol = 1e-10, dense = true, save_everystep = true
+        abstol = 1.0e-10, reltol = 1.0e-10, dense = true, save_everystep = true
     )
 
     function forced!(du, u, eps, t)
@@ -29,15 +29,15 @@ using SciMLSensitivity, OrdinaryDiffEq, LinearAlgebra, Test
     Gof(e) = begin
         s = solve(
             ODEProblem(forced!, u0, tspan, [e]), Tsit5();
-            abstol = 1e-11, reltol = 1e-11
+            abstol = 1.0e-11, reltol = 1.0e-11
         )
         dot(v, s.u[end])
     end
-    fd = (Gof(1e-6) - Gof(-1e-6)) / 2e-6
+    fd = (Gof(1.0e-6) - Gof(-1.0e-6)) / 2.0e-6
 
     sol = solve(
         ODEProblem(forced!, u0, tspan, [0.0]), Tsit5();
-        abstol = 1e-10, reltol = 1e-10, dense = true, save_everystep = true
+        abstol = 1.0e-10, reltol = 1.0e-10, dense = true, save_everystep = true
     )
     dgdu = (out, u, p, t, i) -> (copyto!(out, v); nothing)
 
@@ -49,8 +49,8 @@ using SciMLSensitivity, OrdinaryDiffEq, LinearAlgebra, Test
         ]
         _, dp = adjoint_sensitivities(
             sol, Tsit5(); sensealg = sa, t = [tspan[2]],
-            dgdu_discrete = dgdu, abstol = 1e-10, reltol = 1e-10
+            dgdu_discrete = dgdu, abstol = 1.0e-10, reltol = 1.0e-10
         )
-        @test only(dp) ≈ fd rtol = 1e-5
+        @test only(dp) ≈ fd rtol = 1.0e-5
     end
 end


### PR DESCRIPTION
## Summary

Two mechanical CI fixes:

1. **ExplicitImports QA**: `adjoint`, `copyto!`, and `transpose` are owned by `Base` and are no longer public in `LinearAlgebra` on Julia 1.13 — import them from `Base` instead (e.g. QA job on run [34590667340](https://github.com/SciML/SciMLSensitivity.jl/actions/runs/34590667340)).
2. **format-check**: Runic-format `test/Core3/reversediff_interpolant_forcing.jl` (e.g. format-check on run [34468314723](https://github.com/SciML/SciMLSensitivity.jl/actions/runs/34468314723)).

## Test plan

- [x] `isformatted` check on the test file passes
- [x] QA group passes locally on Julia 1.13 (20/20)

🤖 Generated with [Devin](https://devin.ai) (harness: Devin CLI, model: SWE-2 Max)
Session transcript (local, no shareable URL): /home/crackauc/.local/share/devin/cli/summaries/history_343a17b425e94c53.md