### PR TITLE
Release SciMLSensitivity 7.119.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLSensitivity"
 uuid = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
-version = "7.119.5"
+version = "7.119.6"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Bumps `SciMLSensitivity` 7.119.5 -> 7.119.6 (patch).

Source files changed since 7.119.5:
- `ext/SciMLSensitivityMooncakeExt.jl`
- `src/adjoint_common.jl`
- `src/backsolve_adjoint.jl`
- `src/callback_tracking.jl`
- `src/concrete_solve.jl`
- `src/dae_adjoint.jl`
- `src/gauss_adjoint.jl`
- `src/interpolating_adjoint.jl`
- `src/quadrature_adjoint.jl`

Commits:
- Make checkpointed InterpolatingAdjoint event lift version-robust (#1653)
- Preserve structured tunables type when resetting callback integrand (#1654)
- Despecialize AutoSpecialize FunctionWrappers in adjoint and forward sensitivity paths (#1655)
- Keep the DAE adjoint in residual form when no algorithm is given (#1641)
- Solve without wrapping inside the sensitivity rules (#1640)
- Add AirspeedVelocity benchmarking CI (#1652)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
