### PR TITLE
Add GaussAdjoint edge-case regression tests

### DIFF
--- a/test/Core3/gauss_zygote_inplace.jl
+++ b/test/Core3/gauss_zygote_inplace.jl
@@ -127,3 +127,56 @@ end
     @test dp_enzyme ≈ dp_zygote rtol = 1.0e-6
     @test dp_enzyme ≈ dp_fd rtol = 1.0e-6
 end
+
+# Regression tests for https://github.com/SciML/SciMLSensitivity.jl/issues/994,
+# #995, #996: GaussAdjoint edge cases (non-exact-zero sensitivities, `nothing`
+# gradients, complex state).
+@testset "GaussAdjoint edge cases" begin
+    dynamics(x, p, t) = x
+
+    # #994 / #995: parameters unused by the dynamics — gradient must not error
+    # and should be exactly zero.
+    function zero_loss(params; autojacvec)
+        u0 = zeros(2)
+        problem = ODEProblem(dynamics, u0, (0.0, 1.0), params)
+        rollout = solve(
+            problem, Tsit5(), u0 = u0, p = params,
+            sensealg = GaussAdjoint(autojacvec = autojacvec)
+        )
+        return sum(Array(rollout)[:, end])
+    end
+
+    dp_nothing = Zygote.gradient(
+        p -> zero_loss(p; autojacvec = ZygoteVJP(allow_nothing = true)), [1.0]
+    )[1]
+    dp_plain = Zygote.gradient(
+        p -> zero_loss(p; autojacvec = ZygoteVJP()), [1.0]
+    )[1]
+    @test dp_nothing === nothing || all(iszero, dp_nothing)
+    @test dp_plain === nothing || all(iszero, dp_plain)
+
+    # #996: complex-valued state.
+    dynamics_c(x, p, t) = -x * p[1]
+    function loss2_c(params)
+        u0 = [1.0 + 1.0im]
+        problem = ODEProblem(dynamics_c, u0, (0.0, 1.0), params)
+        rollout = solve(
+            problem, Tsit5(), u0 = u0, p = params,
+            sensealg = GaussAdjoint(autodiff = false, autojacvec = false)
+        )
+        return abs(sum(Array(rollout)[:, end]))
+    end
+    function loss2_interp(params)
+        u0 = [1.0 + 1.0im]
+        problem = ODEProblem(dynamics_c, u0, (0.0, 1.0), params)
+        rollout = solve(
+            problem, Tsit5(), u0 = u0, p = params,
+            sensealg = InterpolatingAdjoint(autodiff = false, autojacvec = false)
+        )
+        return abs(sum(Array(rollout)[:, end]))
+    end
+    dp_gauss = Zygote.gradient(loss2_c, ones(1))[1]
+    dp_interp = Zygote.gradient(loss2_interp, ones(1))[1]
+    @test dp_gauss !== nothing && all(isfinite, dp_gauss)
+    @test dp_gauss ≈ dp_interp rtol = 1.0e-2
+end


### PR DESCRIPTION
## Summary

Regression tests for `GaussAdjoint` issue reports verified fixed on SciMLSensitivity v7.119.4 (Julia 1.12.4):

- #994 / #995: parameters unused by the dynamics — `Zygote.gradient` through `GaussAdjoint(autojacvec = ZygoteVJP())` (and `allow_nothing = true`) returns zero rather than erroring
- #996: complex-valued state — `GaussAdjoint` gradient matches `InterpolatingAdjoint`

#### Test plan

- [x] New testset passes locally: `GaussAdjoint edge cases`: 4/4
- [x] Runic formatted

🤖 Generated with Devin (harness: Devin CLI; model: SWE-2 Max). Session transcript (local): /home/crackauc/.local/share/devin/cli/summaries/history_ee18806f575d4e4c.md