### PR TITLE
Release SciMLSensitivity 7.119.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLSensitivity"
 uuid = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
-version = "7.119.6"
+version = "7.119.7"
 authors = ["Christopher Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Bumps `SciMLSensitivity` 7.119.6 -> 7.119.7 (patch).

Source files changed since 7.119.6:
- `src/SciMLSensitivity.jl`
- `src/concrete_solve.jl`

Commits:
- Add GaussAdjoint edge-case regression tests (#1658)
- Import Base-owned names from Base; Runic-format reversediff_interpolant_forcing test (#1656)
- Remake lazily inside init_loss so the init gradient is taken once (#1643)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
